### PR TITLE
feat(firebase): configure Firebase Admin SDK service for token verification

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -10,6 +10,11 @@ IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS=false
 FRONTEND_URL=http://localhost:3001
 
 # ———————— Optional ————————
+# ———————— Firebase ————————
+# FIREBASE_PROJECT_ID=your-project-id
+# FIREBASE_SERVICE_ACCOUNT_KEY='{"type": "service_account", ...}'
+# FIREBASE_SERVICE_ACCOUNT_KEY_PATH=/path/to/service-account-file.json
+# FIREBASE_DATABASE_URL=https://your-project-id.firebaseio.com
 # PORT=3000
 # ACCESS_TOKEN_EXPIRES_IN=30m
 # LOGIN_TOKEN_EXPIRES_IN=15m

--- a/packages/twenty-server/src/engine/core-modules/firebase/__tests__/firebase-admin.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/firebase/__tests__/firebase-admin.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { FirebaseAdminService } from '../firebase-admin.service';
+import { FIREBASE_ADMIN_APP } from '../firebase.constants';
+import * as admin from 'firebase-admin';
+
+describe('FirebaseAdminService', () => {
+  let service: FirebaseAdminService;
+  let mockFirebaseApp: any;
+
+  beforeEach(async () => {
+    mockFirebaseApp = {
+      auth: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FirebaseAdminService,
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: mockFirebaseApp,
+        },
+      ],
+    }).compile();
+
+    service = module.get<FirebaseAdminService>(FirebaseAdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('auth', () => {
+    it('should return firebase auth instance', () => {
+      const mockAuthInstance = {};
+      mockFirebaseApp.auth.mockReturnValue(mockAuthInstance);
+
+      expect(service.auth).toBe(mockAuthInstance);
+      expect(mockFirebaseApp.auth).toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException when auth initialization fails', () => {
+      mockFirebaseApp.auth.mockImplementation(() => {
+        throw new Error('Firebase not initialized');
+      });
+
+      expect(() => service.auth).toThrow(InternalServerErrorException);
+      expect(() => service.auth).toThrow('Failed to initialize Firebase Auth');
+    });
+  });
+
+  describe('verifyIdToken', () => {
+    it('should successfully verify token', async () => {
+      const mockDecodedToken = { uid: '123' } as admin.auth.DecodedIdToken;
+      const mockAuthInstance = {
+        verifyIdToken: jest.fn().mockResolvedValue(mockDecodedToken),
+      };
+      mockFirebaseApp.auth.mockReturnValue(mockAuthInstance);
+
+      const result = await service.verifyIdToken('valid-token');
+
+      expect(result).toBe(mockDecodedToken);
+      expect(mockAuthInstance.verifyIdToken).toHaveBeenCalledWith('valid-token');
+    });
+
+    it('should throw error when verification fails', async () => {
+      const mockError = new Error('Invalid token');
+      const mockAuthInstance = {
+        verifyIdToken: jest.fn().mockRejectedValue(mockError),
+      };
+      mockFirebaseApp.auth.mockReturnValue(mockAuthInstance);
+
+      await expect(service.verifyIdToken('invalid-token')).rejects.toThrow(mockError);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/firebase/firebase-admin.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/firebase/firebase-admin.service.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import * as admin from 'firebase-admin';
+import { FIREBASE_ADMIN_APP } from './firebase.constants';
+
+@Injectable()
+export class FirebaseAdminService {
+  private readonly logger = new Logger(FirebaseAdminService.name);
+
+  constructor(
+    @Inject(FIREBASE_ADMIN_APP)
+    private readonly firebaseApp: admin.app.App,
+  ) {}
+
+  public get auth(): admin.auth.Auth {
+    try {
+      return this.firebaseApp.auth();
+    } catch (error) {
+      this.logger.error('Failed to initialize Firebase Auth', error);
+      throw new InternalServerErrorException('Failed to initialize Firebase Auth');
+    }
+  }
+
+  public async verifyIdToken(token: string): Promise<admin.auth.DecodedIdToken> {
+    try {
+      return await this.auth.verifyIdToken(token);
+    } catch (error) {
+      this.logger.error('Failed to verify Firebase ID token', error);
+      throw error;
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/firebase/firebase.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/firebase/firebase.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TwentyConfigModule } from '../twenty-config/twenty-config.module';
 import { FirebaseAdminProvider } from './firebase-admin.provider';
+import { FirebaseAdminService } from './firebase-admin.service';
 
 @Module({
   imports: [TwentyConfigModule],
-  providers: [FirebaseAdminProvider],
-  exports: [FirebaseAdminProvider],
+  providers: [FirebaseAdminProvider, FirebaseAdminService],
+  exports: [FirebaseAdminProvider, FirebaseAdminService],
 })
 export class FirebaseModule {}


### PR DESCRIPTION
This PR configures the `twenty-server` with a NestJS service wrapper for the Firebase Admin SDK to handle Auth token verification (`verifyIdToken`). This is required for the upcoming Phase 2 Auth Migration.

Changes include:
- Adding Firebase configuration variable templates to the `Optional` section of `packages/twenty-server/.env.example`.
- Implementing `FirebaseAdminService` (`packages/twenty-server/src/engine/core-modules/firebase/firebase-admin.service.ts`) with an `auth` getter and a `verifyIdToken(token: string)` method, including proper error handling.
- Registering and exporting `FirebaseAdminService` within `FirebaseModule` (`packages/twenty-server/src/engine/core-modules/firebase/firebase.module.ts`).
- Adding unit tests for `FirebaseAdminService` (`packages/twenty-server/src/engine/core-modules/firebase/__tests__/firebase-admin.service.spec.ts`) to verify correct instantiation and behavior of the underlying Firebase SDK calls.

---
*PR created automatically by Jules for task [18335791794834186117](https://jules.google.com/task/18335791794834186117) started by @dllewellyn*