### PR TITLE
Finalize Firebase Token Management

### DIFF
--- a/packages/twenty-front/src/modules/apollo/services/__tests__/apollo.factory.test.ts
+++ b/packages/twenty-front/src/modules/apollo/services/__tests__/apollo.factory.test.ts
@@ -9,21 +9,13 @@ import { WorkspaceActivationStatus } from '~/generated-metadata/graphql';
 
 enableFetchMocks();
 
-jest.mock('@/auth/services/AuthService', () => {
-  const initialAuthService = jest.requireActual('@/auth/services/AuthService');
-  return {
-    ...initialAuthService,
-    renewToken: jest.fn().mockReturnValue(
-      Promise.resolve({
-        accessOrWorkspaceAgnosticToken: {
-          token: 'newAccessToken',
-          expiresAt: '',
-        },
-        refreshToken: { token: 'newRefreshToken', expiresAt: '' },
-      }),
-    ),
-  };
-});
+jest.mock('~/modules/auth/firebase', () => ({
+  auth: {
+    currentUser: {
+      getIdToken: jest.fn().mockResolvedValue('newAccessToken'),
+    },
+  },
+}));
 
 const mockOnError = jest.fn();
 const mockOnNetworkError = jest.fn();

--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -15,7 +15,6 @@ import { RetryLink } from '@apollo/client/link/retry';
 import { RestLink } from 'apollo-link-rest';
 import { createUploadLink } from 'apollo-upload-client';
 
-import { renewToken } from '@/auth/services/AuthService';
 import { type CurrentWorkspaceMember } from '@/auth/states/currentWorkspaceMemberState';
 import { type CurrentWorkspace } from '@/auth/states/currentWorkspaceState';
 import { type AuthTokenPair } from '~/generated-metadata/graphql';
@@ -36,9 +35,8 @@ import {
 } from 'graphql';
 import isEmpty from 'lodash.isempty';
 import { getGenericOperationName, isDefined } from 'twenty-shared/utils';
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { cookieStorage } from '~/utils/cookie-storage';
-import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+import { auth } from '~/modules/auth/firebase';
 
 const logger = loggerLink(() => 'Twenty');
 
@@ -102,27 +100,29 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
       });
 
       const authLink = setContext(async (_, { headers }) => {
-        const tokenPair = getTokenPair();
+        let token: string | undefined;
 
-        const locale = this.currentWorkspaceMember?.locale ?? i18n.locale;
-
-        if (isUndefinedOrNull(tokenPair)) {
-          return {
-            headers: {
-              ...headers,
-              ...options.headers,
-              'x-locale': locale,
-            },
-          };
+        if (auth.currentUser?.getIdToken) {
+          try {
+            token = await auth.currentUser.getIdToken();
+          } catch (e) {
+            // oxlint-disable-next-line no-console
+            console.error('Failed to get Firebase ID token', e);
+          }
         }
 
-        const token = tokenPair.accessOrWorkspaceAgnosticToken?.token;
+        if (!token) {
+          const tokenPair = getTokenPair();
+          token = tokenPair?.accessOrWorkspaceAgnosticToken?.token;
+        }
+
+        const locale = this.currentWorkspaceMember?.locale ?? i18n.locale;
 
         return {
           headers: {
             ...headers,
             ...options.headers,
-            authorization: token ? `Bearer ${token}` : '',
+            ...(token ? { authorization: `Bearer ${token}` } : {}),
             'x-locale': locale,
             ...(this.currentWorkspace?.metadataVersion && {
               'X-Schema-Version': `${this.currentWorkspace.metadataVersion}`,
@@ -157,22 +157,31 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
         forward: (operation: Operation) => Observable<FetchResult>,
       ) => {
         if (!renewalPromise) {
-          // Always renew through /metadata since the RenewToken is only exposed there
-          const graphqlUri = `${REACT_APP_SERVER_BASE_URL}/metadata`;
+          renewalPromise = (async () => {
+            if (!auth.currentUser?.getIdToken) {
+              throw new Error('No Firebase user available for token renewal');
+            }
 
-          renewalPromise = renewToken(graphqlUri, getTokenPair())
-            .then((tokens) => {
-              if (isDefined(tokens)) {
-                // oxlint-disable-next-line no-console
-                console.log('setTokenPair from handleTokenRenewal');
-                onTokenPairChange?.(tokens);
-                cookieStorage.setItem('tokenPair', JSON.stringify(tokens));
-              }
-            })
-            .catch(() => {
+            const token = await auth.currentUser.getIdToken(true);
+            if (!token) {
+              throw new Error('Failed to retrieve refreshed token');
+            }
+
+            const tokens: AuthTokenPair = {
+              accessOrWorkspaceAgnosticToken: { token, expiresAt: '' },
+              refreshToken: { token: '', expiresAt: '' },
+            };
+
+            // oxlint-disable-next-line no-console
+            console.log('setTokenPair from handleTokenRenewal');
+            onTokenPairChange?.(tokens);
+            cookieStorage.setItem('tokenPair', JSON.stringify(tokens));
+          })()
+            .catch((error) => {
               // oxlint-disable-next-line no-console
               console.log(
                 'Failed to renew token, triggering unauthenticated error from handleTokenRenewal',
+                error,
               );
               onUnauthenticatedError?.();
             })

--- a/packages/twenty-front/src/modules/auth/hooks/useOnAuthStateChanged.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useOnAuthStateChanged.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { onAuthStateChanged } from 'firebase/auth';
+import { onIdTokenChanged } from 'firebase/auth';
 
 import { auth } from '~/modules/auth/firebase';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
@@ -13,7 +13,7 @@ export const useOnAuthStateChanged = () => {
   const { loadCurrentUser } = useLoadCurrentUser();
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+    const unsubscribe = onIdTokenChanged(auth, async (user) => {
       if (user) {
         // User is signed in, get the new token
         const token = await user.getIdToken();

--- a/packages/twenty-front/src/modules/auth/services/AuthService.ts
+++ b/packages/twenty-front/src/modules/auth/services/AuthService.ts
@@ -48,6 +48,9 @@ const renewTokenMutation = async (
   return data;
 };
 
+/**
+ * @deprecated Legacy logic to renew tokens; replaced by Firebase ID tokens.
+ */
 export const renewToken = async (
   uri: string | UriFunction | undefined,
   tokenPair: AuthTokenPair | undefined | null,


### PR DESCRIPTION
This submission finalizes token management via Firebase for Apollo GraphQL interactions. It guarantees tokens are properly fetched through the Firebase SDK (`onIdTokenChanged` and `getIdToken()`) and enforces automatic renewal internally when receiving unauthenticated responses, eliminating the dependency on custom `/metadata` backend renewals.

The related tests and codebase were cleaned up to align with this standard.

---
*PR created automatically by Jules for task [3145021362389877730](https://jules.google.com/task/3145021362389877730) started by @dllewellyn*