### PR TITLE
refactor: decommission legacy JWT auth in backend

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.spec.ts
@@ -1,8 +1,8 @@
-import { Test, type TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import bcrypt from 'bcrypt';
-import { type Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { Repository } from 'typeorm';
 
 import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
 import { AuditService } from 'src/engine/core-modules/audit/services/audit.service';
@@ -16,7 +16,7 @@ import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/
 import { LoginTokenService } from 'src/engine/core-modules/auth/token/services/login-token.service';
 import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
 import { WorkspaceAgnosticTokenService } from 'src/engine/core-modules/auth/token/services/workspace-agnostic-token.service';
-import { type ExistingUserOrNewUser } from 'src/engine/core-modules/auth/types/signInUp.type';
+import { ExistingUserOrNewUser } from 'src/engine/core-modules/auth/types/signInUp.type';
 import { DomainServerConfigService } from 'src/engine/core-modules/domain/domain-server-config/services/domain-server-config.service';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { EmailService } from 'src/engine/core-modules/email/email.service';
@@ -191,198 +191,6 @@ describe('AuthService', () => {
     userRepository = module.get<Repository<UserEntity>>(
       getRepositoryToken(UserEntity),
     );
-    permissionsService = module.get<PermissionsService>(PermissionsService);
-    signInUpServiceMock = module.get(SignInUpService) as jest.Mocked<
-      Pick<SignInUpService, 'validatePassword'>
-    >;
-  });
-
-  beforeEach(() => {
-    twentyConfigServiceGetMock.mockReturnValue(false);
-    signInUpServiceMock.validatePassword.mockClear();
-  });
-
-  it('should be defined', async () => {
-    expect(service).toBeDefined();
-  });
-
-  it('challenge - user already member of workspace', async () => {
-    const workspace = { isPasswordAuthEnabled: true } as WorkspaceEntity;
-    const user = {
-      email: 'email',
-      password: 'password',
-      captchaToken: 'captchaToken',
-    };
-
-    (bcrypt.compare as jest.Mock).mockReturnValueOnce(true);
-
-    jest.spyOn(userRepository, 'findOne').mockReturnValueOnce({
-      email: user.email,
-      passwordHash: 'passwordHash',
-      captchaToken: user.captchaToken,
-    } as unknown as Promise<UserEntity>);
-
-    jest
-      .spyOn(userWorkspaceService, 'checkUserWorkspaceExists')
-      .mockReturnValueOnce({} as any);
-
-    const response = await service.validateLoginWithPassword(
-      {
-        email: 'email',
-        password: 'password',
-        captchaToken: 'captchaToken',
-      },
-      workspace,
-    );
-
-    expect(response).toStrictEqual({
-      email: user.email,
-      passwordHash: 'passwordHash',
-      captchaToken: user.captchaToken,
-    });
-  });
-
-  it('allows password login through SSO bypass when user has permission', async () => {
-    const workspace = {
-      id: 'workspace-id',
-      isPasswordAuthEnabled: false,
-      isPasswordAuthBypassEnabled: true,
-    } as WorkspaceEntity;
-
-    const userEntity = {
-      id: 'user-id',
-      email: 'email',
-      passwordHash: 'password-hash',
-      userWorkspaces: [
-        {
-          id: 'user-workspace-id',
-          workspaceId: workspace.id,
-        } as any,
-      ],
-    } as unknown as UserEntity;
-
-    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-
-    jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(userEntity);
-    jest
-      .spyOn(userWorkspaceService, 'checkUserWorkspaceExists')
-      .mockResolvedValueOnce({ id: 'user-workspace-id' } as any);
-    jest
-      .spyOn(permissionsService, 'userHasWorkspaceSettingPermission')
-      .mockResolvedValueOnce(true);
-
-    const response = await service.validateLoginWithPassword(
-      {
-        email: 'email',
-        password: 'password',
-        captchaToken: 'captcha-token',
-      },
-      workspace,
-    );
-
-    expect(response).toBe(userEntity);
-  });
-
-  it('throws when bypass permission is missing for disabled password auth', async () => {
-    const workspace = {
-      id: 'workspace-id',
-      isPasswordAuthEnabled: false,
-      isPasswordAuthBypassEnabled: true,
-    } as WorkspaceEntity;
-
-    const userEntity = {
-      id: 'user-id',
-      email: 'email',
-      passwordHash: 'password-hash',
-      userWorkspaces: [
-        {
-          id: 'user-workspace-id',
-          workspaceId: workspace.id,
-        } as any,
-      ],
-    } as unknown as UserEntity;
-
-    jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(userEntity);
-    jest
-      .spyOn(userWorkspaceService, 'checkUserWorkspaceExists')
-      .mockResolvedValueOnce(null);
-    jest
-      .spyOn(permissionsService, 'userHasWorkspaceSettingPermission')
-      .mockResolvedValueOnce(false);
-
-    await expect(
-      service.validateLoginWithPassword(
-        {
-          email: 'email',
-          password: 'password',
-          captchaToken: 'captcha-token',
-        },
-        workspace,
-      ),
-    ).rejects.toThrow(
-      new AuthException(
-        'Email/Password auth is not enabled for this workspace',
-        AuthExceptionCode.FORBIDDEN_EXCEPTION,
-      ),
-    );
-    expect(signInUpServiceMock.validatePassword).not.toHaveBeenCalled();
-  });
-
-  it('challenge - user who have an invitation', async () => {
-    const user = {
-      email: 'email',
-      password: 'password',
-      captchaToken: 'captchaToken',
-    };
-
-    const UserFindOneSpy = jest
-      .spyOn(userRepository, 'findOne')
-      .mockReturnValueOnce({
-        email: user.email,
-        passwordHash: 'passwordHash',
-        captchaToken: user.captchaToken,
-      } as unknown as Promise<UserEntity>);
-
-    (bcrypt.compare as jest.Mock).mockReturnValueOnce(true);
-    jest
-      .spyOn(userWorkspaceService, 'checkUserWorkspaceExists')
-      .mockReturnValueOnce(null as any);
-
-    const getOneWorkspaceInvitationSpy = jest
-      .spyOn(workspaceInvitationService, 'getOneWorkspaceInvitation')
-      .mockReturnValueOnce({} as any);
-
-    const workspaceInvitationValidatePersonalInvitationSpy = jest
-      .spyOn(workspaceInvitationService, 'validatePersonalInvitation')
-      .mockReturnValueOnce({} as any);
-
-    const addUserToWorkspaceIfUserNotInWorkspaceSpy = jest
-      .spyOn(userWorkspaceService, 'addUserToWorkspaceIfUserNotInWorkspace')
-      .mockReturnValueOnce({} as any);
-
-    const response = await service.validateLoginWithPassword(
-      {
-        email: 'email',
-        password: 'password',
-        captchaToken: 'captchaToken',
-      },
-      {
-        isPasswordAuthEnabled: true,
-      } as WorkspaceEntity,
-    );
-
-    expect(response).toStrictEqual({
-      email: user.email,
-      passwordHash: 'passwordHash',
-      captchaToken: user.captchaToken,
-    });
-
-    expect(getOneWorkspaceInvitationSpy).toHaveBeenCalledTimes(1);
-    expect(
-      workspaceInvitationValidatePersonalInvitationSpy,
-    ).toHaveBeenCalledTimes(1);
-    expect(addUserToWorkspaceIfUserNotInWorkspaceSpy).toHaveBeenCalledTimes(1);
-    expect(UserFindOneSpy).toHaveBeenCalledTimes(1);
   });
 
   describe('checkAccessForSignIn', () => {
@@ -454,6 +262,7 @@ describe('AuthService', () => {
             isPublicInviteLinkEnabled: false,
             approvedAccessDomains: [],
           } as unknown as WorkspaceEntity,
+          authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
         }),
       ).rejects.toThrow(
         new AuthException(
@@ -478,6 +287,7 @@ describe('AuthService', () => {
         invitation: undefined,
         workspaceInviteHash: undefined,
         workspace: undefined,
+        authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
       });
 
       expect(spy).toHaveBeenCalledTimes(0);
@@ -498,6 +308,7 @@ describe('AuthService', () => {
         invitation: undefined,
         workspaceInviteHash: undefined,
         workspace: undefined,
+        authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
       });
 
       expect(spy).toHaveBeenCalledTimes(0);
@@ -518,6 +329,7 @@ describe('AuthService', () => {
         invitation: {} as AppTokenEntity,
         workspaceInviteHash: undefined,
         workspace: { approvedAccessDomains: [] } as unknown as WorkspaceEntity,
+        authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
       });
 
       expect(spy).toHaveBeenCalledTimes(0);
@@ -539,6 +351,7 @@ describe('AuthService', () => {
           isPublicInviteLinkEnabled: true,
           approvedAccessDomains: [],
         } as unknown as WorkspaceEntity,
+        authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
       });
 
       expect(spy).toHaveBeenCalledTimes(0);
@@ -561,6 +374,7 @@ describe('AuthService', () => {
               { domain: 'domain.com', isValidated: true },
             ],
           } as unknown as WorkspaceEntity,
+          authParams: { provider: AuthProviderEnum.Password, password: 'pw' },
         });
       }).not.toThrow();
     });


### PR DESCRIPTION
# Legacy Auth Decommissioning

This PR finalizes the transition to the Firebase-native authentication system in `twenty-server` by completely removing the legacy JWT-based authentication infrastructure.

## Changes Made
- **Deleted Core Files:** Removed `jwt.auth.strategy.ts`, `jwt.auth.strategy.spec.ts`, and `jwt-auth.guard.ts`.
- **Module Cleanup:** Removed `JwtAuthStrategy` from `AuthModule` and `TokenModule` providers arrays.
- **Service Refactoring:**
  - `AccessTokenService`: Removed the legacy `validateToken` and `validateTokenByRequest` methods along with `JwtAuthStrategy` dependencies.
  - `AuthService`: Removed legacy authentication flows including `validateLoginWithPassword`, `signInUp`, `verify`, and `generateImpersonationAccessTokenAndRefreshToken`. Fixed associated `auth.service.spec.ts` unit tests.
- **GraphQL Resolver Cleanup:** Removed deprecated `AuthResolver` mutations (`signIn`, `signUp`, `renewToken`, `getAuthTokensFromOTP`, etc.).
- **Global Strategy Replacements:** Replaced all leftover instances of `accessTokenService.validateTokenByRequest` with the newly standardized `firebaseAuthStrategy.validate` in core engine services (`MiddlewareService`, `OpenApiService`, `RouteTriggerService`, `RestApiMetadataService`).

---
*PR created automatically by Jules for task [1497281316356697916](https://jules.google.com/task/1497281316356697916) started by @dllewellyn*