### PR TITLE
feat(metadata): implement dynamic schema validation via Firestore

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/MIGRATION_STRATEGY.md
+++ b/packages/twenty-server/src/engine/metadata-modules/MIGRATION_STRATEGY.md
@@ -1,0 +1,62 @@
+# Metadata Migration Strategy: Postgres to Firestore
+
+## Context
+As part of transitioning the `twenty-server` backend architecture from a PostgreSQL-based engine to a Firebase-native architecture, we need to migrate existing object and field metadata into a dynamic, JSON Schema-driven collection in Firestore named `_metadata`. This document outlines the migration design.
+
+## Target Structure
+The target is a single `_metadata` collection in Firestore.
+Documents represent individual object types within a specific workspace (supporting multi-tenancy).
+
+**Document Structure:**
+```json
+{
+  "id": "uuid-string",
+  "workspaceId": "workspace-uuid-string", // or "system" for core entities
+  "nameSingular": "person",
+  "namePlural": "people",
+  "labelSingular": "Person",
+  "labelPlural": "People",
+  "isCustom": true,
+  "jsonSchema": {
+    "$id": "people-schema",
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "format": "uuid" },
+      "name": { "type": "string" },
+      // ... mapped fields
+    },
+    "required": ["name"]
+  },
+  "uiMetadata": {
+    "icon": "IconUser",
+    "description": "A person object"
+  }
+}
+```
+
+## Migration Logic Sequence
+
+1. **Read Entities from Postgres**
+   - Query all records from the `ObjectMetadataEntity` table.
+   - For each object, query its associated `FieldMetadataEntity` records.
+   - Filter or separate system objects (`isSystem: true`) to assign them to `workspaceId: "system"`.
+
+2. **Map Postgres Types to JSON Schema**
+   - Iterate through `FieldMetadataEntity` records and map their types.
+   - `UUID` -> `{ "type": "string", "format": "uuid" }`
+   - `TEXT` / `VARCHAR` -> `{ "type": "string" }`
+   - `NUMBER` -> `{ "type": "number" }`
+   - `BOOLEAN` -> `{ "type": "boolean" }`
+   - `RELATION` -> Map to nested objects or string references depending on how relations will be handled in Firestore (e.g., storing the related object's UUID).
+   - Gather all non-nullable fields (`isNullable: false`) and add their names to the `required` array of the JSON schema.
+
+3. **Handle Edge Cases and Legacy Data**
+   - **Defensive Traversal**: Wrap field access in `try/catch` or use optional chaining to handle corrupted legacy records gracefully.
+   - **AJV Formats**: Standard formats like `email`, `uuid`, and `date-time` should be mapped explicitly since the `MetadataService` enables `ajv-formats`.
+
+4. **Transform to `_metadata` Format**
+   - Construct the final JSON object matching the `_metadata` document structure for each mapped object.
+
+5. **Seed the Firestore Collection**
+   - Use `firebase-admin` batch writes to push the transformed documents to the `_metadata` collection.
+   - For emulator testing, use a seed script connected to `FIRESTORE_EMULATOR_HOST="127.0.0.1:8080"`.

--- a/packages/twenty-server/src/engine/metadata-modules/__tests__/metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/__tests__/metadata.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MetadataService } from '../metadata.service';
+import { FIREBASE_ADMIN_APP } from '../../core-modules/firebase/firebase.constants';
+
+describe('MetadataService', () => {
+  let service: MetadataService;
+  let mockFirestore: any;
+
+  beforeEach(async () => {
+    // Mock for Firestore
+    mockFirestore = {
+      collection: jest.fn().mockReturnValue({
+        onSnapshot: jest.fn(),
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({ docs: [] }),
+      }),
+    };
+
+    const mockFirebaseApp = {
+      firestore: jest.fn().mockReturnValue(mockFirestore),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MetadataService,
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: mockFirebaseApp,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MetadataService>(MetadataService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should correctly cache and compile json schema validators', async () => {
+    const testSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    };
+
+    service.updateCache('workspace1', 'users', testSchema);
+
+    const { validator, partialValidator } = await service.getValidator('users', 'workspace1');
+
+    expect(validator).toBeDefined();
+    expect(partialValidator).toBeDefined();
+
+    // The full validator should require 'name'
+    expect(validator({})).toBe(false);
+    expect(validator({ name: 'test' })).toBe(true);
+
+    // The partial validator should allow omitting required fields
+    expect(partialValidator({})).toBe(true);
+  });
+
+  it('should clear existing schemas when recompiling to avoid ID conflicts', async () => {
+    const testSchema = {
+      $id: 'user-schema',
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    service.updateCache('workspace1', 'users', testSchema);
+
+    // Attempting to compile again with the same $id shouldn't throw an error
+    // because we implemented `this.ajv.removeSchema` inside `updateCache`
+    expect(() => {
+      service.updateCache('workspace1', 'users', testSchema);
+    }).not.toThrow();
+  });
+
+  it('should fallback to system schema if not found in workspace cache', async () => {
+    const testSchema = {
+      type: 'object',
+      properties: {
+        systemField: { type: 'boolean' },
+      },
+    };
+
+    service.updateCache('system', 'config', testSchema);
+
+    // Get validator for 'workspace1' should fall back to 'system' since it's missing in 'workspace1'
+    const { validator } = await service.getValidator('config', 'workspace1');
+    expect(validator).toBeDefined();
+    expect(validator({ systemField: true })).toBe(true);
+  });
+
+  it('should fetch from Firestore if missing in caches', async () => {
+    // Mock the Firestore to return a document
+    const testSchema = {
+      type: 'object',
+      properties: {
+        remoteField: { type: 'string' },
+      },
+    };
+
+    mockFirestore.collection().get.mockResolvedValueOnce({
+      docs: [
+        {
+          data: () => ({
+            workspaceId: 'workspace1',
+            namePlural: 'remote-objects',
+            jsonSchema: testSchema,
+          }),
+        },
+      ],
+    });
+
+    const { validator } = await service.getValidator('remote-objects', 'workspace1');
+    expect(validator).toBeDefined();
+    expect(validator({ remoteField: 'test' })).toBe(true);
+    expect(mockFirestore.collection().get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
@@ -22,6 +22,7 @@ import { SkillModule } from 'src/engine/metadata-modules/skill/skill.module';
 import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
 import { WebhookModule } from 'src/engine/metadata-modules/webhook/webhook.module';
 import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
 
 @Module({
   imports: [
@@ -47,12 +48,14 @@ import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/work
     WebhookModule,
   ],
   providers: [
+    MetadataService,
     {
       provide: APP_FILTER,
       useClass: FlatEntityMapsGraphqlApiExceptionFilter,
     },
   ],
   exports: [
+    MetadataService,
     DataSourceModule,
     FieldMetadataModule,
     FrontComponentModule,

--- a/packages/twenty-server/src/engine/metadata-modules/metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata.service.ts
@@ -1,0 +1,160 @@
+import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import * as admin from 'firebase-admin';
+import Ajv, { AnySchema, ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import { FIREBASE_ADMIN_APP } from '../core-modules/firebase/firebase.constants';
+
+export interface MetadataValidator {
+  validator: ValidateFunction;
+  partialValidator: ValidateFunction;
+}
+
+@Injectable()
+export class MetadataService implements OnModuleInit, OnModuleDestroy {
+  private readonly db: admin.firestore.Firestore;
+  private unsubscribe: (() => void) | null = null;
+  private ajv: Ajv;
+
+  // Cache structure: workspaceId -> objectName -> MetadataValidator
+  private validatorsCache: Map<string, Map<string, MetadataValidator>> = new Map();
+
+  constructor(
+    @Inject(FIREBASE_ADMIN_APP) private readonly firebaseApp?: admin.app.App,
+  ) {
+    this.db = this.firebaseApp
+      ? this.firebaseApp.firestore()
+      : admin.firestore();
+
+    this.ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(this.ajv);
+  }
+
+  async onModuleInit() {
+    this.initListeners();
+  }
+
+  onModuleDestroy() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+  }
+
+  private initListeners() {
+    const collection = this.db.collection('_metadata');
+
+    this.unsubscribe = collection.onSnapshot(
+      (snapshot) => {
+        snapshot.docChanges().forEach((change) => {
+          const doc = change.doc;
+          const data = doc.data();
+          const workspaceId = data.workspaceId;
+          // Use namePlural as the default collection/object name, fallback to nameSingular
+          const objectName = data.namePlural || data.nameSingular;
+
+          if (change.type === 'added' || change.type === 'modified') {
+            this.updateCache(workspaceId, objectName, data.jsonSchema);
+          } else if (change.type === 'removed') {
+            this.removeFromCache(workspaceId, objectName);
+          }
+        });
+      },
+      (error) => {
+        console.error('Error listening to _metadata changes', error);
+      },
+    );
+  }
+
+  public updateCache(workspaceId: string, objectName: string, jsonSchema: AnySchema) {
+    if (!workspaceId || !objectName || !jsonSchema) return;
+
+    let workspaceCache = this.validatorsCache.get(workspaceId);
+    if (!workspaceCache) {
+      workspaceCache = new Map();
+      this.validatorsCache.set(workspaceId, workspaceCache);
+    }
+
+    try {
+      const schemaObj = jsonSchema as any;
+      if (schemaObj.$id && this.ajv.getSchema(schemaObj.$id)) {
+        this.ajv.removeSchema(schemaObj.$id);
+      }
+      const validator = this.ajv.compile(jsonSchema);
+
+      const partialSchema = { ...jsonSchema } as Record<string, unknown> & {
+        required?: string[];
+      };
+      if (partialSchema.required) {
+        delete partialSchema.required;
+      }
+      if (partialSchema.$id) {
+        partialSchema.$id = `${partialSchema.$id}-partial`;
+        if (this.ajv.getSchema(partialSchema.$id)) {
+          this.ajv.removeSchema(partialSchema.$id);
+        }
+      }
+      const partialValidator = this.ajv.compile(partialSchema);
+
+      workspaceCache.set(objectName, {
+        validator,
+        partialValidator,
+      });
+    } catch (e) {
+      console.error(`Error compiling schema for ${objectName} in workspace ${workspaceId}:`, e);
+    }
+  }
+
+  private removeFromCache(workspaceId: string, objectName: string) {
+    const workspaceCache = this.validatorsCache.get(workspaceId);
+    if (workspaceCache) {
+      workspaceCache.delete(objectName);
+    }
+  }
+
+  public async getValidator(objectName: string, workspaceId: string): Promise<MetadataValidator> {
+    // Check workspace specific cache
+    const workspaceCache = this.validatorsCache.get(workspaceId);
+    if (workspaceCache && workspaceCache.has(objectName)) {
+      return workspaceCache.get(objectName)!;
+    }
+
+    // Check system cache
+    const systemCache = this.validatorsCache.get('system');
+    if (systemCache && systemCache.has(objectName)) {
+      return systemCache.get(objectName)!;
+    }
+
+    // If not in cache, fetch it from Firestore directly
+    let querySnapshot;
+    try {
+      querySnapshot = await this.db.collection('_metadata')
+        .where('workspaceId', 'in', [workspaceId, 'system'])
+        .get();
+    } catch (e) {
+      console.error('Error fetching metadata schemas from Firestore:', e);
+      throw new Error(`Validator not found for object ${objectName} in workspace ${workspaceId}`);
+    }
+
+    // Populate cache for missing
+    for (const doc of querySnapshot.docs) {
+      const data = doc.data();
+      const wsId = data.workspaceId;
+      const key = data.namePlural || data.nameSingular;
+      if (wsId && key && data.jsonSchema) {
+        this.updateCache(wsId, key, data.jsonSchema);
+      }
+    }
+
+    // Re-check caches
+    const updatedWorkspaceCache = this.validatorsCache.get(workspaceId);
+    if (updatedWorkspaceCache && updatedWorkspaceCache.has(objectName)) {
+      return updatedWorkspaceCache.get(objectName)!;
+    }
+
+    const updatedSystemCache = this.validatorsCache.get('system');
+    if (updatedSystemCache && updatedSystemCache.has(objectName)) {
+      return updatedSystemCache.get(objectName)!;
+    }
+
+    throw new Error(`Validator not found for object ${objectName} in workspace ${workspaceId}`);
+  }
+}

--- a/packages/twenty-server/src/engine/twenty-orm/repository/__tests__/firestore.repository.integration-spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/__tests__/firestore.repository.integration-spec.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '.env.test' });
 import * as admin from 'firebase-admin';
 import { BaseFirestoreRepository } from '../firestore.repository';
+import { MetadataService } from '../../../metadata-modules/metadata.service';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -17,6 +18,7 @@ describe('BaseFirestoreRepository Integration', () => {
   let db: admin.firestore.Firestore;
   let repository: BaseFirestoreRepository<any>;
   let createdDocId: string;
+  let mockMetadataService: MetadataService;
 
   beforeAll(async () => {
     // Disable fake timers for this specific test suite as gRPC requires real timers to function
@@ -35,9 +37,27 @@ describe('BaseFirestoreRepository Integration', () => {
       ssl: false,
     });
 
+    // We can instantiate MetadataService normally or create a complete mock.
+    // Here we use the real service with the firebaseApp but update its cache manually to avoid needing `_metadata` setup in emulator
+    mockMetadataService = new MetadataService(admin.app());
+    mockMetadataService.updateCache('test_workspace', 'test_fields', createFieldSchema);
+
+    // We override getValidator to ensure it only reads from cache so we don't need real Firestore calls for `_metadata`
+    jest.spyOn(mockMetadataService, 'getValidator').mockImplementation(async (objectName: string, workspaceId: string) => {
+       // Since updateCache was called above, the cache has this populated
+       // We can directly call the real method or replicate cache checking logic.
+       // We'll just return from the internal cache property or we can let the real method throw if missing
+       const cache = (mockMetadataService as any).validatorsCache.get(workspaceId);
+       if (cache && cache.has(objectName)) {
+         return cache.get(objectName);
+       }
+       throw new Error(`Validator not found`);
+    });
+
     repository = new BaseFirestoreRepository(
       'test_fields',
-      createFieldSchema,
+      mockMetadataService,
+      'test_workspace',
       admin.app(),
     );
   });
@@ -47,6 +67,8 @@ describe('BaseFirestoreRepository Integration', () => {
     if (createdDocId) {
       await repository.delete(createdDocId);
     }
+    mockMetadataService.onModuleDestroy();
+
     // Delete the default app to prevent issues with other tests that might use firebase-admin
     if (admin.apps.length > 0 && admin.app()) {
       await admin.app().delete();

--- a/packages/twenty-server/src/engine/twenty-orm/repository/firestore.repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/firestore.repository.ts
@@ -1,10 +1,7 @@
 import { Inject } from '@nestjs/common';
 import * as admin from 'firebase-admin';
-import Ajv, { AnySchema, ValidateFunction } from 'ajv';
 import { FIREBASE_ADMIN_APP } from '../../core-modules/firebase/firebase.constants';
-import addFormats from 'ajv-formats';
-import * as fs from 'fs';
-import * as path from 'path';
+import { MetadataService } from '../../metadata-modules/metadata.service';
 
 /**
  * Base repository for Firestore-backed entities.
@@ -15,97 +12,32 @@ import * as path from 'path';
  * **Limitations compared to standard TypeORM Repository:**
  * - Limited query parsing in `find()` (basic equality, some simple operators like moreThan, lessThan, in).
  * - Only basic support for `skip` and `take` based on Firestore's native pagination capabilities. No complex ordering logic out-of-the-box.
- * - Validation is done via `ajv` and extracted JSON schemas instead of class-validator decorators.
+ * - Validation is done via `ajv` and dynamically fetched JSON schemas instead of class-validator decorators.
  * - Does not natively manage complex relation mappings out-of-the-box in the same way TypeORM does.
  */
 export class BaseFirestoreRepository<T extends Record<string, any>> {
   protected readonly db: admin.firestore.Firestore;
   protected readonly collection: admin.firestore.CollectionReference;
-  protected readonly ajv: Ajv;
-  protected readonly validator: ValidateFunction;
-  protected readonly partialValidator: ValidateFunction;
-  protected schema: AnySchema;
 
   constructor(
     protected readonly collectionName: string,
-    schemaOrName: AnySchema | string,
+    protected readonly metadataService: MetadataService,
+    protected readonly workspaceId: string,
     @Inject(FIREBASE_ADMIN_APP) protected readonly firebaseApp?: admin.app.App,
   ) {
     this.db = this.firebaseApp
       ? this.firebaseApp.firestore()
       : admin.firestore();
     this.collection = this.db.collection(this.collectionName);
-
-    this.ajv = new Ajv({ allErrors: true, strict: false });
-    addFormats(this.ajv);
-
-    // Load all schemas from the json-schemas directory dynamically
-    const schemasPath = path.join(
-      __dirname,
-      '../../metadata-modules/json-schemas',
-    );
-    if (fs.existsSync(schemasPath)) {
-      const files = fs.readdirSync(schemasPath);
-      for (const file of files) {
-        if (file.endsWith('.json')) {
-          try {
-            const rawSchema = fs.readFileSync(
-              path.join(schemasPath, file),
-              'utf8',
-            );
-            const parsedSchema = JSON.parse(rawSchema);
-            if (parsedSchema.$id) {
-              // Ensure we don't add the same schema twice if ajv automatically handles some
-              if (!this.ajv.getSchema(parsedSchema.$id)) {
-                this.ajv.addSchema(parsedSchema);
-              }
-            } else {
-              // Fallback if schema doesn't have an ID, use filename
-              const id = file.replace('.json', '');
-              parsedSchema.$id = id;
-              if (!this.ajv.getSchema(id)) {
-                this.ajv.addSchema(parsedSchema);
-              }
-            }
-          } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error(`Error loading schema from ${file}:`, e);
-          }
-        }
-      }
-    }
-
-    if (typeof schemaOrName === 'string') {
-      const rawSchema = fs.readFileSync(
-        path.join(schemasPath, `${schemaOrName}.json`),
-        'utf8',
-      );
-      this.schema = JSON.parse(rawSchema);
-    } else {
-      this.schema = schemaOrName;
-    }
-
-    this.validator = this.ajv.compile(this.schema);
-
-    // Create a partial schema for update validation
-    // Removing the 'required' field from the schema properties to allow partial updates
-    const partialSchema = { ...this.schema } as Record<string, unknown> & {
-      required?: string[];
-    };
-    if (partialSchema.required) {
-      delete partialSchema.required;
-    }
-    if (partialSchema.$id) {
-      partialSchema.$id = `${partialSchema.$id}-partial`;
-    }
-    this.partialValidator = this.ajv.compile(partialSchema);
   }
 
   async create(data: T): Promise<admin.firestore.DocumentReference> {
-    const isValid = this.validator(data);
+    const { validator } = await this.metadataService.getValidator(this.collectionName, this.workspaceId);
+
+    const isValid = validator(data);
     if (!isValid) {
       throw new Error(
-        `Validation failed: ${this.ajv.errorsText(this.validator.errors)}`,
+        `Validation failed: ${JSON.stringify(validator.errors)}`,
       );
     }
 
@@ -116,10 +48,12 @@ export class BaseFirestoreRepository<T extends Record<string, any>> {
     id: string,
     data: Partial<T>,
   ): Promise<admin.firestore.WriteResult> {
-    const isValid = this.partialValidator(data);
+    const { partialValidator } = await this.metadataService.getValidator(this.collectionName, this.workspaceId);
+
+    const isValid = partialValidator(data);
     if (!isValid) {
       throw new Error(
-        `Partial validation failed: ${this.ajv.errorsText(this.partialValidator.errors)}`,
+        `Partial validation failed: ${JSON.stringify(partialValidator.errors)}`,
       );
     }
 
@@ -194,12 +128,14 @@ export class BaseFirestoreRepository<T extends Record<string, any>> {
   }
 
   async save(data: T | T[]): Promise<T | T[]> {
+    const { validator } = await this.metadataService.getValidator(this.collectionName, this.workspaceId);
+
     if (Array.isArray(data)) {
       for (const item of data) {
-        const isValid = this.validator(item);
+        const isValid = validator(item);
         if (!isValid) {
           throw new Error(
-            `Validation failed: ${this.ajv.errorsText(this.validator.errors)}`,
+            `Validation failed: ${JSON.stringify(validator.errors)}`,
           );
         }
       }
@@ -219,10 +155,10 @@ export class BaseFirestoreRepository<T extends Record<string, any>> {
       await batch.commit();
       return data;
     } else {
-      const isValid = this.validator(data);
+      const isValid = validator(data);
       if (!isValid) {
         throw new Error(
-          `Validation failed: ${this.ajv.errorsText(this.validator.errors)}`,
+          `Validation failed: ${JSON.stringify(validator.errors)}`,
         );
       }
       const docRef = data.id
@@ -272,13 +208,15 @@ export class BaseFirestoreRepository<T extends Record<string, any>> {
   }
 
   async insert(data: any | any[]): Promise<any> {
+    const { validator } = await this.metadataService.getValidator(this.collectionName, this.workspaceId);
+
     const items = Array.isArray(data) ? data : [data];
 
     for (const item of items) {
-      const isValid = this.validator(item);
+      const isValid = validator(item);
       if (!isValid) {
         throw new Error(
-          `Validation failed: ${this.ajv.errorsText(this.validator.errors)}`,
+          `Validation failed: ${JSON.stringify(validator.errors)}`,
         );
       }
     }


### PR DESCRIPTION
This PR addresses Phase 3: Metadata Migration Strategy by replacing the static JSON file validation in `BaseFirestoreRepository` with a dynamic, multi-tenant approach.

### Changes:
1. **MetadataService**: Introduced a new service in `packages/twenty-server/src/engine/metadata-modules/metadata.service.ts` that acts as a schema registry. It connects to the `_metadata` Firestore collection, compiles `ajv` validators, and updates its in-memory cache proactively via an `onSnapshot` listener.
2. **BaseFirestoreRepository Refactor**: Modified the repository constructor and methods to inject and utilize `MetadataService` for both full and partial validation, allowing for custom, workspace-specific object schemas.
3. **Migration Strategy**: Documented the planned migration logic mapping Postgres types to JSON Schema structures in `MIGRATION_STRATEGY.md`.
4. **Testing**: Implemented unit tests for the caching logic and updated the existing integration specs to use the new service dependency.

---
*PR created automatically by Jules for task [7061196481691113782](https://jules.google.com/task/7061196481691113782) started by @dllewellyn*