### PR TITLE
feat(database): Add command to migrate People records to Firestore

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CronRegisterAllCommand } from 'src/database/commands/cron-register-all.command';
 import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-workspace.command';
 import { ListOrphanedWorkspaceEntitiesCommand } from 'src/database/commands/list-and-delete-orphaned-workspace-entities.command';
+import { MigratePeopleCommand } from 'src/database/commands/migrate-people.command';
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
 import { UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/upgrade-version-command.module';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
@@ -18,7 +19,9 @@ import { PublicDomainModule } from 'src/engine/core-modules/public-domain/public
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { FirebaseModule } from 'src/engine/core-modules/firebase/firebase.module';
 import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
+import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engine.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { TrashCleanupModule } from 'src/engine/trash-cleanup/trash-cleanup.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
@@ -55,6 +58,8 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     WorkspaceCleanerModule,
     WorkspaceMigrationModule,
     TrashCleanupModule,
+    MetadataEngineModule,
+    FirebaseModule,
     PublicDomainModule,
     EventLogCleanupModule,
     MarketplaceModule,
@@ -66,6 +71,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     CronRegisterAllCommand,
     ListOrphanedWorkspaceEntitiesCommand,
     GenerateApiKeyCommand,
+    MigratePeopleCommand,
   ],
 })
 export class DatabaseCommandModule {}

--- a/packages/twenty-server/src/database/commands/migrate-people.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/migrate-people.command.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MigratePeopleCommand } from './migrate-people.command';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+
+jest.mock('src/engine/twenty-orm/repository/firestore.repository');
+
+describe('MigratePeopleCommand', () => {
+  let command: MigratePeopleCommand;
+  let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
+  let metadataService: jest.Mocked<MetadataService>;
+
+  const mockPersonRepository = {
+    find: jest.fn(),
+  };
+
+  const mockFirestoreRepository = {
+    save: jest.fn(),
+  };
+
+  (BaseFirestoreRepository as jest.Mock).mockImplementation(
+    () => mockFirestoreRepository,
+  );
+
+  beforeEach(async () => {
+    globalWorkspaceOrmManager = {
+      getRepository: jest.fn().mockResolvedValue(mockPersonRepository),
+    } as any;
+
+    metadataService = {} as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MigratePeopleCommand,
+        {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: GlobalWorkspaceOrmManager,
+          useValue: globalWorkspaceOrmManager,
+        },
+        {
+          provide: DataSourceService,
+          useValue: {},
+        },
+        {
+          provide: MetadataService,
+          useValue: metadataService,
+        },
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    command = module.get<MigratePeopleCommand>(MigratePeopleCommand);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  it('should not migrate if no people are found', async () => {
+    mockPersonRepository.find.mockResolvedValue([]);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'person',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'No people found for workspace workspace-1.',
+    );
+  });
+
+  it('should migrate people successfully', async () => {
+    const mockPersons = [
+      { id: '1', name: 'John Doe' },
+      { id: '2', name: 'Jane Doe' },
+    ];
+    mockPersonRepository.find.mockResolvedValue(mockPersons);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'person',
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenCalledWith(mockPersons);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Migrating 2 people for workspace workspace-1...',
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Successfully migrated 2 people for workspace workspace-1.',
+    );
+  });
+
+  it('should not save if dryRun is true', async () => {
+    const mockPersons = [
+      { id: '1', name: 'John Doe' },
+      { id: '2', name: 'Jane Doe' },
+    ];
+    mockPersonRepository.find.mockResolvedValue(mockPersons);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: { dryRun: true, workspaceIds: [] },
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'person',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      '[DRY RUN] Would migrate 2 people for workspace workspace-1.',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/migrate-people.command.ts
+++ b/packages/twenty-server/src/database/commands/migrate-people.command.ts
@@ -1,0 +1,94 @@
+import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as admin from 'firebase-admin';
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
+
+@Command({
+  name: 'database:migrate-people',
+  description: 'Migrates people records from PostgreSQL to Firestore.',
+})
+export class MigratePeopleCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+    protected readonly metadataService: MetadataService,
+    @Inject(FIREBASE_ADMIN_APP)
+    protected readonly firebaseApp: admin.app.App,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  public async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    try {
+      const personRepository =
+        await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
+          workspaceId,
+          'person',
+        );
+
+      const firestoreRepository =
+        new BaseFirestoreRepository<PersonWorkspaceEntity>(
+          'people',
+          this.metadataService,
+          workspaceId,
+          this.firebaseApp,
+        );
+
+      const persons = await personRepository.find();
+
+      if (persons.length === 0) {
+        this.logger.log(`No people found for workspace ${workspaceId}.`);
+        return;
+      }
+
+      const transformedPersons = persons.map((person) => {
+        // Map TypeORM entity to a plain object
+        return {
+          ...person,
+          // Preserve relational IDs if needed, they are usually on the object
+          // For instance, person.companyId
+        };
+      });
+
+      if (options.dryRun) {
+        this.logger.log(
+          `[DRY RUN] Would migrate ${transformedPersons.length} people for workspace ${workspaceId}.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Migrating ${transformedPersons.length} people for workspace ${workspaceId}...`,
+      );
+
+      // Save using batch operation
+      await firestoreRepository.save(transformedPersons);
+
+      this.logger.log(
+        `Successfully migrated ${transformedPersons.length} people for workspace ${workspaceId}.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to migrate people for workspace ${workspaceId}.`,
+        error,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Implemented a command `database:migrate-people` to batch process and migrate existing 'People' records from PostgreSQL to the new Firestore 'people' collection for Phase 3 refactoring. Includes support for executing on specific workspace IDs and dry runs. Tests added and successfully run against NestJS testing infrastructure.

---
*PR created automatically by Jules for task [506348807492868406](https://jules.google.com/task/506348807492868406) started by @dllewellyn*