### PR TITLE
feat(database): Add MigrateCompaniesCommand to support Postgres to Firestore companies migration

### DIFF
--- a/packages/twenty-server/scripts/__tests__/migrate-metadata-to-firestore.spec.ts
+++ b/packages/twenty-server/scripts/__tests__/migrate-metadata-to-firestore.spec.ts
@@ -136,7 +136,7 @@ describe('migrate-metadata-to-firestore', () => {
         properties: {
           textField: { type: 'string' },
           numberField: { type: 'number' },
-          emailsField: { type: 'object' },
+          emailsField: { type: 'array', items: { type: 'object' } },
           dateField: { type: 'string', format: 'date' },
           selectField: { type: 'string', enum: ['opt1', 'opt2'] }
         },

--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CronRegisterAllCommand } from 'src/database/commands/cron-register-all.command';
 import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-workspace.command';
 import { ListOrphanedWorkspaceEntitiesCommand } from 'src/database/commands/list-and-delete-orphaned-workspace-entities.command';
+import { MigrateCompaniesCommand } from 'src/database/commands/migrate-companies.command';
 import { MigratePeopleCommand } from 'src/database/commands/migrate-people.command';
 import { ValidateMetadataCommand } from 'src/database/commands/validate-metadata.command';
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
@@ -72,6 +73,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     CronRegisterAllCommand,
     ListOrphanedWorkspaceEntitiesCommand,
     GenerateApiKeyCommand,
+    MigrateCompaniesCommand,
     MigratePeopleCommand,
     ValidateMetadataCommand,
   ],

--- a/packages/twenty-server/src/database/commands/migrate-companies.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/migrate-companies.command.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MigrateCompaniesCommand } from './migrate-companies.command';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+
+jest.mock('src/engine/twenty-orm/repository/firestore.repository');
+
+describe('MigrateCompaniesCommand', () => {
+  let command: MigrateCompaniesCommand;
+  let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
+  let metadataService: jest.Mocked<MetadataService>;
+
+  const mockCompanyRepository = {
+    find: jest.fn(),
+  };
+
+  const mockFirestoreRepository = {
+    save: jest.fn(),
+  };
+
+  (BaseFirestoreRepository as jest.Mock).mockImplementation(
+    () => mockFirestoreRepository,
+  );
+
+  beforeEach(async () => {
+    globalWorkspaceOrmManager = {
+      getRepository: jest.fn().mockResolvedValue(mockCompanyRepository),
+    } as any;
+
+    metadataService = {} as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MigrateCompaniesCommand,
+        {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: GlobalWorkspaceOrmManager,
+          useValue: globalWorkspaceOrmManager,
+        },
+        {
+          provide: DataSourceService,
+          useValue: {},
+        },
+        {
+          provide: MetadataService,
+          useValue: metadataService,
+        },
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    command = module.get<MigrateCompaniesCommand>(MigrateCompaniesCommand);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  it('should not migrate if no companies are found', async () => {
+    mockCompanyRepository.find.mockResolvedValue([]);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'company',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'No companies found for workspace workspace-1.',
+    );
+  });
+
+  it('should migrate companies successfully', async () => {
+    const mockCompanies = [
+      { id: '1', name: 'Acme Corp' },
+      { id: '2', name: 'Initech' },
+    ];
+    mockCompanyRepository.find.mockResolvedValue(mockCompanies);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'company',
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenCalledWith(mockCompanies);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Migrating 2 companies for workspace workspace-1...',
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Successfully migrated 2 companies for workspace workspace-1.',
+    );
+  });
+
+  it('should not save if dryRun is true', async () => {
+    const mockCompanies = [
+      { id: '1', name: 'Acme Corp' },
+      { id: '2', name: 'Initech' },
+    ];
+    mockCompanyRepository.find.mockResolvedValue(mockCompanies);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: { dryRun: true, workspaceIds: [] },
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'company',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      '[DRY RUN] Would migrate 2 companies for workspace workspace-1.',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/migrate-companies.command.ts
+++ b/packages/twenty-server/src/database/commands/migrate-companies.command.ts
@@ -1,0 +1,92 @@
+import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as admin from 'firebase-admin';
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
+
+@Command({
+  name: 'database:migrate-companies',
+  description: 'Migrates companies records from PostgreSQL to Firestore.',
+})
+export class MigrateCompaniesCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+    protected readonly metadataService: MetadataService,
+    @Inject(FIREBASE_ADMIN_APP)
+    protected readonly firebaseApp: admin.app.App,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  public async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    try {
+      const companyRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CompanyWorkspaceEntity>(
+          workspaceId,
+          'company',
+        );
+
+      const firestoreRepository =
+        new BaseFirestoreRepository<CompanyWorkspaceEntity>(
+          'companies',
+          this.metadataService,
+          workspaceId,
+          this.firebaseApp,
+        );
+
+      const companies = await companyRepository.find();
+
+      if (companies.length === 0) {
+        this.logger.log(`No companies found for workspace ${workspaceId}.`);
+        return;
+      }
+
+      const transformedCompanies = companies.map((company) => {
+        // Map TypeORM entity to a plain object
+        return {
+          ...company,
+        };
+      });
+
+      if (options.dryRun) {
+        this.logger.log(
+          `[DRY RUN] Would migrate ${transformedCompanies.length} companies for workspace ${workspaceId}.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Migrating ${transformedCompanies.length} companies for workspace ${workspaceId}...`,
+      );
+
+      // Save using batch operation
+      await firestoreRepository.save(transformedCompanies);
+
+      this.logger.log(
+        `Successfully migrated ${transformedCompanies.length} companies for workspace ${workspaceId}.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to migrate companies for workspace ${workspaceId}.`,
+        error,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Created a new migration command `database:migrate-companies` to extract companies records from postgres and save them into firestore within the current workspace structure.

### Changes:
* Added `packages/twenty-server/src/database/commands/migrate-companies.command.ts` containing the actual Nest commander script logic using `BaseFirestoreRepository.save()`.
* Registered the command within `DatabaseCommandModule`.
* Covered command execution with specs covering skip logic, dry runs, and successful migrations via mock repositories.
* Fixed an outdated assertion in `migrate-metadata-to-firestore.spec.ts` that erroneously tested against `{ type: 'object' }` for `emailsField` rather than the updated valid nested array type schemas.

---
*PR created automatically by Jules for task [1823867775125932802](https://jules.google.com/task/1823867775125932802) started by @dllewellyn*