### PR TITLE
feat(server): add MigrateNotesCommand for Note entity migration

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -5,6 +5,7 @@ import { CronRegisterAllCommand } from 'src/database/commands/cron-register-all.
 import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-workspace.command';
 import { ListOrphanedWorkspaceEntitiesCommand } from 'src/database/commands/list-and-delete-orphaned-workspace-entities.command';
 import { MigrateCompaniesCommand } from 'src/database/commands/migrate-companies.command';
+import { MigrateNotesCommand } from 'src/database/commands/migrate-notes.command';
 import { MigratePeopleCommand } from 'src/database/commands/migrate-people.command';
 import { ValidateMetadataCommand } from 'src/database/commands/validate-metadata.command';
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
@@ -74,6 +75,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     ListOrphanedWorkspaceEntitiesCommand,
     GenerateApiKeyCommand,
     MigrateCompaniesCommand,
+    MigrateNotesCommand,
     MigratePeopleCommand,
     ValidateMetadataCommand,
   ],

--- a/packages/twenty-server/src/database/commands/migrate-notes.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/migrate-notes.command.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MigrateNotesCommand } from './migrate-notes.command';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+
+jest.mock('src/engine/twenty-orm/repository/firestore.repository');
+
+describe('MigrateNotesCommand', () => {
+  let command: MigrateNotesCommand;
+  let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
+  let metadataService: jest.Mocked<MetadataService>;
+
+  const mockNoteRepository = {
+    find: jest.fn(),
+  };
+
+  const mockFirestoreRepository = {
+    save: jest.fn(),
+  };
+
+  (BaseFirestoreRepository as jest.Mock).mockImplementation(
+    () => mockFirestoreRepository,
+  );
+
+  beforeEach(async () => {
+    globalWorkspaceOrmManager = {
+      getRepository: jest.fn().mockResolvedValue(mockNoteRepository),
+    } as any;
+
+    metadataService = {} as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MigrateNotesCommand,
+        {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: GlobalWorkspaceOrmManager,
+          useValue: globalWorkspaceOrmManager,
+        },
+        {
+          provide: DataSourceService,
+          useValue: {},
+        },
+        {
+          provide: MetadataService,
+          useValue: metadataService,
+        },
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    command = module.get<MigrateNotesCommand>(MigrateNotesCommand);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  it('should not migrate if no notes are found', async () => {
+    mockNoteRepository.find.mockResolvedValue([]);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'note',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'No notes found for workspace workspace-1.',
+    );
+  });
+
+  it('should migrate notes successfully', async () => {
+    const mockNotes = [
+      { id: '1', title: 'Note 1' },
+      { id: '2', title: 'Note 2' },
+    ];
+    mockNoteRepository.find.mockResolvedValue(mockNotes);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'note',
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenCalledWith(mockNotes);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Migrating 2 notes for workspace workspace-1...',
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Successfully migrated 2 notes for workspace workspace-1.',
+    );
+  });
+
+  it('should not save if dryRun is true', async () => {
+    const mockNotes = [
+      { id: '1', title: 'Note 1' },
+      { id: '2', title: 'Note 2' },
+    ];
+    mockNoteRepository.find.mockResolvedValue(mockNotes);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: { dryRun: true, workspaceIds: [] },
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'note',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      '[DRY RUN] Would migrate 2 notes for workspace workspace-1.',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/migrate-notes.command.ts
+++ b/packages/twenty-server/src/database/commands/migrate-notes.command.ts
@@ -1,0 +1,96 @@
+import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as admin from 'firebase-admin';
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+import { NoteWorkspaceEntity } from 'src/modules/note/standard-objects/note.workspace-entity';
+
+@Command({
+  name: 'database:migrate-notes',
+  description: 'Migrates notes records from PostgreSQL to Firestore.',
+})
+export class MigrateNotesCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+    protected readonly metadataService: MetadataService,
+    @Inject(FIREBASE_ADMIN_APP)
+    protected readonly firebaseApp: admin.app.App,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  public async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    try {
+      const noteRepository =
+        await this.globalWorkspaceOrmManager.getRepository<NoteWorkspaceEntity>(
+          workspaceId,
+          'note',
+        );
+
+      const firestoreRepository =
+        new BaseFirestoreRepository<NoteWorkspaceEntity>(
+          'notes',
+          this.metadataService,
+          workspaceId,
+          this.firebaseApp,
+        );
+
+      const notes = await noteRepository.find();
+
+      if (notes.length === 0) {
+        this.logger.log(`No notes found for workspace ${workspaceId}.`);
+        return;
+      }
+
+      const transformedNotes = notes.map((note) => {
+        // Map TypeORM entity to a plain object
+        return {
+          ...note,
+        };
+      });
+
+      if (options.dryRun) {
+        this.logger.log(
+          `[DRY RUN] Would migrate ${transformedNotes.length} notes for workspace ${workspaceId}.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Migrating ${transformedNotes.length} notes for workspace ${workspaceId}...`,
+      );
+
+      // Save using batch operation with limits
+      const FIRESTORE_BATCH_LIMIT = 500;
+      for (let i = 0; i < transformedNotes.length; i += FIRESTORE_BATCH_LIMIT) {
+        const chunk = transformedNotes.slice(i, i + FIRESTORE_BATCH_LIMIT);
+        await firestoreRepository.save(chunk);
+      }
+
+      this.logger.log(
+        `Successfully migrated ${transformedNotes.length} notes for workspace ${workspaceId}.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to migrate notes for workspace ${workspaceId}.`,
+        error,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new CLI command `database:migrate-notes` to facilitate the migration of Note records from PostgreSQL to the new Firestore `notes` collection. It handles chunking correctly to avoid hitting the 500-record batch limit of Firestore and maps entities safely. Included are unit tests and module registration.

---
*PR created automatically by Jules for task [6129334096315082739](https://jules.google.com/task/6129334096315082739) started by @dllewellyn*