### PR TITLE
Add database:migrate-opportunities command

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -6,6 +6,7 @@ import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-wo
 import { ListOrphanedWorkspaceEntitiesCommand } from 'src/database/commands/list-and-delete-orphaned-workspace-entities.command';
 import { MigrateCompaniesCommand } from 'src/database/commands/migrate-companies.command';
 import { MigrateNotesCommand } from 'src/database/commands/migrate-notes.command';
+import { MigrateOpportunitiesCommand } from 'src/database/commands/migrate-opportunities.command';
 import { MigratePeopleCommand } from 'src/database/commands/migrate-people.command';
 import { MigrateTasksCommand } from 'src/database/commands/migrate-tasks.command';
 import { ValidateMetadataCommand } from 'src/database/commands/validate-metadata.command';
@@ -77,6 +78,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     GenerateApiKeyCommand,
     MigrateCompaniesCommand,
     MigrateNotesCommand,
+    MigrateOpportunitiesCommand,
     MigratePeopleCommand,
     MigrateTasksCommand,
     ValidateMetadataCommand,

--- a/packages/twenty-server/src/database/commands/migrate-opportunities.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/migrate-opportunities.command.spec.ts
@@ -1,0 +1,178 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+import { MigrateOpportunitiesCommand } from './migrate-opportunities.command';
+
+jest.mock('src/engine/twenty-orm/repository/firestore.repository');
+
+describe('MigrateOpportunitiesCommand', () => {
+  let command: MigrateOpportunitiesCommand;
+  let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
+  let metadataService: jest.Mocked<MetadataService>;
+
+  const mockOpportunityRepository = {
+    find: jest.fn(),
+  };
+
+  const mockFirestoreRepository = {
+    save: jest.fn(),
+  };
+
+  (BaseFirestoreRepository as jest.Mock).mockImplementation(
+    () => mockFirestoreRepository,
+  );
+
+  beforeEach(async () => {
+    globalWorkspaceOrmManager = {
+      getRepository: jest.fn().mockResolvedValue(mockOpportunityRepository),
+    } as any;
+
+    metadataService = {} as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MigrateOpportunitiesCommand,
+        {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: GlobalWorkspaceOrmManager,
+          useValue: globalWorkspaceOrmManager,
+        },
+        {
+          provide: DataSourceService,
+          useValue: {},
+        },
+        {
+          provide: MetadataService,
+          useValue: metadataService,
+        },
+        {
+          provide: FIREBASE_ADMIN_APP,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    command = module.get<MigrateOpportunitiesCommand>(MigrateOpportunitiesCommand);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(command).toBeDefined();
+  });
+
+  it('should not migrate if no opportunities are found', async () => {
+    mockOpportunityRepository.find.mockResolvedValue([]);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'opportunity',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'No opportunities found for workspace workspace-1.',
+    );
+  });
+
+  it('should migrate opportunities successfully', async () => {
+    const mockOpportunities = [
+      { id: '1', name: 'Opportunity 1' },
+      { id: '2', name: 'Opportunity 2' },
+    ];
+    mockOpportunityRepository.find.mockResolvedValue(mockOpportunities);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'opportunity',
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenCalledWith(mockOpportunities);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Migrating 2 opportunities for workspace workspace-1...',
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Successfully migrated 2 opportunities for workspace workspace-1.',
+    );
+  });
+
+  it('should chunk the migrations up correctly according to FIRESTORE_BATCH_LIMIT', async () => {
+    const mockOpportunities = Array.from({ length: 1200 }, (_, i) => ({
+      id: i.toString(),
+      name: `Opportunity ${i}`,
+    }));
+    mockOpportunityRepository.find.mockResolvedValue(mockOpportunities);
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(mockFirestoreRepository.save).toHaveBeenCalledTimes(3);
+    expect(mockFirestoreRepository.save).toHaveBeenNthCalledWith(
+      1,
+      mockOpportunities.slice(0, 500),
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenNthCalledWith(
+      2,
+      mockOpportunities.slice(500, 1000),
+    );
+    expect(mockFirestoreRepository.save).toHaveBeenNthCalledWith(
+      3,
+      mockOpportunities.slice(1000, 1200),
+    );
+  });
+
+  it('should not save if dryRun is true', async () => {
+    const mockOpportunities = [
+      { id: '1', name: 'Opportunity 1' },
+      { id: '2', name: 'Opportunity 2' },
+    ];
+    mockOpportunityRepository.find.mockResolvedValue(mockOpportunities);
+    const loggerSpy = jest.spyOn(command['logger'], 'log');
+
+    await command.runOnWorkspace({
+      workspaceId: 'workspace-1',
+      options: { dryRun: true, workspaceIds: [] },
+      index: 0,
+      total: 1,
+    });
+
+    expect(globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+      'workspace-1',
+      'opportunity',
+    );
+    expect(mockFirestoreRepository.save).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      '[DRY RUN] Would migrate 2 opportunities for workspace workspace-1.',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/migrate-opportunities.command.ts
+++ b/packages/twenty-server/src/database/commands/migrate-opportunities.command.ts
@@ -1,0 +1,103 @@
+import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as admin from 'firebase-admin';
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { FIREBASE_ADMIN_APP } from 'src/engine/core-modules/firebase/firebase.constants';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { BaseFirestoreRepository } from 'src/engine/twenty-orm/repository/firestore.repository';
+import { OpportunityWorkspaceEntity } from 'src/modules/opportunity/standard-objects/opportunity.workspace-entity';
+
+@Command({
+  name: 'database:migrate-opportunities',
+  description: 'Migrates opportunities records from PostgreSQL to Firestore.',
+})
+export class MigrateOpportunitiesCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+    protected readonly metadataService: MetadataService,
+    @Inject(FIREBASE_ADMIN_APP)
+    protected readonly firebaseApp: admin.app.App,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  public async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    try {
+      const opportunityRepository =
+        await this.globalWorkspaceOrmManager.getRepository<OpportunityWorkspaceEntity>(
+          workspaceId,
+          'opportunity',
+        );
+
+      const firestoreRepository =
+        new BaseFirestoreRepository<OpportunityWorkspaceEntity>(
+          'opportunities',
+          this.metadataService,
+          workspaceId,
+          this.firebaseApp,
+        );
+
+      const opportunities = await opportunityRepository.find();
+
+      if (opportunities.length === 0) {
+        this.logger.log(`No opportunities found for workspace ${workspaceId}.`);
+        return;
+      }
+
+      const transformedOpportunities = opportunities.map((opportunity) => {
+        // Map TypeORM entity to a plain object
+        return {
+          ...opportunity,
+        };
+      });
+
+      if (options.dryRun) {
+        this.logger.log(
+          `[DRY RUN] Would migrate ${transformedOpportunities.length} opportunities for workspace ${workspaceId}.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Migrating ${transformedOpportunities.length} opportunities for workspace ${workspaceId}...`,
+      );
+
+      // Save using batch operation with limits
+      const FIRESTORE_BATCH_LIMIT = 500;
+      for (
+        let i = 0;
+        i < transformedOpportunities.length;
+        i += FIRESTORE_BATCH_LIMIT
+      ) {
+        const chunk = transformedOpportunities.slice(
+          i,
+          i + FIRESTORE_BATCH_LIMIT,
+        );
+        await firestoreRepository.save(chunk);
+      }
+
+      this.logger.log(
+        `Successfully migrated ${transformedOpportunities.length} opportunities for workspace ${workspaceId}.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to migrate opportunities for workspace ${workspaceId}.`,
+        error,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Develop and run a script to migrate all 'Opportunity' records from PostgreSQL to the Firestore 'opportunities' collection, ensuring it uses the batch processing (500 limit) and any necessary transformations.

---
*PR created automatically by Jules for task [10273584130573655059](https://jules.google.com/task/10273584130573655059) started by @dllewellyn*