### PR TITLE
feat(firestore): Refine security rules for multi-tenant and ownership permissions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,6 @@ I will now update the `TASKS.md` file by removing the preamble, marking the 'Use
 # Task Backlog
 
 ## Phase 3: Data Migration
-- [ ] **Firestore Security Rules**: Define initial security rules based on user ownership and role claims to protect the migrated data.
 - [ ] **Verify User Auth Flow**: Confirm that the excluded `passwordHash` doesn't break the intended Firebase Authentication strategy (e.g., ensuring users can still sign in or identifying the need for a password import/reset strategy).
 - [ ] **End-to-End Migration Validation**: Perform a full audit of all migrated collections (People, Companies, Notes, Tasks, Opportunities, Users) to ensure data integrity, relationship correctness, and consistency with Firestore schemas.
 - [ ] **Batch Processing & Transformation Audit**: Final review of all migration scripts to ensure the 500-record batching limit and transformation utilities (`transformLinksToFirestore`, `transformEmailsToFirestore`, `transformPhonesToFirestore`) were applied consistently and handled all edge cases.
@@ -22,6 +21,7 @@ I will now update the `TASKS.md` file by removing the preamble, marking the 'Use
 - [ ] **Zapier Integration Refactor**: Update the Zapier integration to point to the new Firebase-native API and use Firebase Auth for authentication.
 
 ## COMPLETED WORK
+- [x] **Firestore Security Rules**: Define initial security rules based on user ownership and role claims to protect the migrated data.
 - [x] **Collection Migration: 'Users'**: Developed and ran a script to migrate all 'User' records from PostgreSQL to the Firestore 'users' collection, including JSON schema validation and data transformation for Firebase Auth compatibility.
 - [x] **Collection Migration: 'Opportunities'**: Develop and run a script to migrate all 'Opportunity' records from PostgreSQL to the Firestore 'opportunities' collection.
 - [x] **Collection Migration: 'Tasks'**: Develop and run a script to migrate all 'Task' records from PostgreSQL to the Firestore 'tasks' collection.

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,46 +20,52 @@ service cloud.firestore {
 
     // Rules for each collection
     match /people/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
       allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /noteTargets/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
       allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /companies/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
       allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /notes/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
-      allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /opportunities/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
       allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /tasks/{id} {
-      allow read, delete: if isWorkspaceMember(resource.data.workspaceId);
+      allow read: if isWorkspaceMember(resource.data.workspaceId);
       allow create: if isWorkspaceMember(request.resource.data.workspaceId);
-      allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId);
+      allow update: if isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
+      allow delete: if isWorkspaceMember(resource.data.workspaceId) && (isWorkspaceAdmin() || isOwner(resource.data));
     }
 
     match /users/{id} {
-      allow read: if isWorkspaceMember('system') || (isAuthenticated() && request.auth.uid == id);
-      allow delete: if isWorkspaceMember('system') && resource.data.workspaceId == 'system';
-      allow create: if isWorkspaceMember('system') && request.resource.data.workspaceId == 'system';
-      allow update: if isWorkspaceMember('system') && resource.data.workspaceId == 'system' && request.resource.data.workspaceId == 'system';
+      allow read: if isWorkspaceMember('system') || (isAuthenticated() && request.auth.uid == id) || (isAuthenticated() && request.auth.token.workspaceId == resource.data.workspaceId);
+      allow create: if isWorkspaceMember('system') || (isWorkspaceMember(request.resource.data.workspaceId) && isWorkspaceAdmin());
+      allow update: if isWorkspaceMember('system') || (isAuthenticated() && request.auth.uid == id && resource.data.workspaceId == request.resource.data.workspaceId) || (isWorkspaceMember(resource.data.workspaceId) && isWorkspaceMember(request.resource.data.workspaceId) && isWorkspaceAdmin());
+      allow delete: if isWorkspaceMember('system') || (isWorkspaceMember(resource.data.workspaceId) && isWorkspaceAdmin());
     }
 
     match /_metadata/{id} {

--- a/packages/twenty-server/src/engine/core-modules/firebase/__tests__/firestore.rules.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/firebase/__tests__/firestore.rules.spec.ts
@@ -144,7 +144,7 @@ describe('Firestore Security Rules', () => {
           .firestore()
           .collection('companies')
           .doc('c1')
-          .set({ workspaceId });
+          .set({ workspaceId, createdBy: { id: 'user-1' } });
       });
 
       // A user in otherWorkspace tries to delete the doc from workspace
@@ -177,6 +177,22 @@ describe('Firestore Security Rules', () => {
       expect(doc.exists).toBe(true);
     });
 
+    it('should allow a user to read another user\'s profile in the same workspace', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context
+          .firestore()
+          .collection('users')
+          .doc('user-3')
+          .set({ workspaceId });
+      });
+
+      const doc = await workspaceAuthedDb
+        .collection('users')
+        .doc('user-3')
+        .get();
+      expect(doc.exists).toBe(true);
+    });
+
     it('should not allow users to read other users unless they have system workspace access', async () => {
       await testEnv.withSecurityRulesDisabled(async (context) => {
         await context
@@ -190,6 +206,84 @@ describe('Firestore Security Rules', () => {
       // @ts-expect-error
       await expect(
         workspaceAuthedDb.collection('users').doc('user-2').get(),
+      ).rejects.toThrow();
+    });
+
+    it('should NOT allow a user to read a user\'s profile in a different workspace', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context
+          .firestore()
+          .collection('users')
+          .doc('user-4')
+          .set({ workspaceId: otherWorkspaceId });
+      });
+
+      // @ts-expect-error
+      await expect(
+        workspaceAuthedDb.collection('users').doc('user-4').get(),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('Notes Collection', () => {
+    it('should allow a user to delete their own note', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context.firestore().collection('notes').doc('note1').set({
+          workspaceId: workspaceId,
+          createdBy: { id: 'user-1' }
+        });
+      });
+
+      await expect(
+        workspaceAuthedDb.collection('notes').doc('note1').delete()
+      ).resolves.toBeUndefined();
+    });
+
+    it('should NOT allow a user to delete someone else\'s note', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context.firestore().collection('notes').doc('note2').set({
+          workspaceId: workspaceId,
+          createdBy: { id: 'user-2' }
+        });
+      });
+
+      // @ts-expect-error
+      await expect(
+        workspaceAuthedDb.collection('notes').doc('note2').delete()
+      ).rejects.toThrow();
+    });
+
+    it('should allow a workspace admin to delete any note in their workspace', async () => {
+      const adminAuthedDb = testEnv
+        .authenticatedContext('user-3', {
+          workspaceId: workspaceId,
+          role: 'ADMIN'
+        })
+        .firestore();
+
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context.firestore().collection('notes').doc('note3').set({
+          workspaceId: workspaceId,
+          createdBy: { id: 'user-1' }
+        });
+      });
+
+      await expect(
+        adminAuthedDb.collection('notes').doc('note3').delete()
+      ).resolves.toBeUndefined();
+    });
+
+    it('should NOT allow reading notes from a different workspace', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context.firestore().collection('notes').doc('note4').set({
+          workspaceId: otherWorkspaceId,
+          createdBy: { id: 'user-2' }
+        });
+      });
+
+      // @ts-expect-error
+      await expect(
+        workspaceAuthedDb.collection('notes').doc('note4').get()
       ).rejects.toThrow();
     });
   });


### PR DESCRIPTION
This PR implements fine-grained security rules for the Firestore database in the `twenty` project. The rules use custom claims (`isWorkspaceAdmin()`) and data-based conditions (`isOwner()`) to provide appropriate permissions across the multi-tenant architecture. 

Key changes include:
- Core collections like `companies` and `people` allow all workspace members to read, create, and update, but restrict `delete` to owners or workspace admins.
- Collaborative collections like `notes` and `tasks` restrict both `update` and `delete` to owners or admins.
- The `users` collection allows members to read other members in the same workspace, but requires admin privileges to create or delete users.
- `_metadata` is locked for writes strictly to `isWorkspaceAdmin()`.
- Added test coverage to verify rules logic using the `@firebase/rules-unit-testing` framework.

---
*PR created automatically by Jules for task [3829626478264551446](https://jules.google.com/task/3829626478264551446) started by @dllewellyn*