### PR TITLE
feat(server): add bulk migration command to import legacy users to Firebase Auth

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -15,6 +15,7 @@ import { ValidateMetadataCommand } from 'src/database/commands/validate-metadata
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
 import { BackfillWorkspaceIdCommand } from 'src/database/commands/backfill-workspace-id.command';
 import { VerifyFirebaseUsersCommand } from 'src/database/commands/verify-firebase-users.command';
+import { ImportFirebaseAuthUsersCommand } from 'src/database/commands/import-firebase-auth-users.command';
 import { UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/upgrade-version-command.module';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApiKeyModule } from 'src/engine/core-modules/api-key/api-key.module';
@@ -90,6 +91,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     ValidateMetadataCommand,
     BackfillWorkspaceIdCommand,
     VerifyFirebaseUsersCommand,
+    ImportFirebaseAuthUsersCommand,
   ],
 })
 export class DatabaseCommandModule {}

--- a/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.spec.ts
@@ -1,0 +1,210 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ImportFirebaseAuthUsersCommand } from 'src/database/commands/import-firebase-auth-users.command';
+import { FirebaseAdminService } from 'src/engine/core-modules/firebase/firebase-admin.service';
+import { UserEntity } from 'src/engine/core-modules/user/user.entity';
+
+describe('ImportFirebaseAuthUsersCommand', () => {
+  let command: ImportFirebaseAuthUsersCommand;
+  let userRepositoryMock: any;
+  let firebaseAdminServiceMock: any;
+  let importUsersMock: jest.Mock;
+  let loggerLogSpy: jest.SpyInstance;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    userRepositoryMock = {
+      find: jest.fn(),
+    };
+
+    importUsersMock = jest.fn().mockResolvedValue({
+      successCount: 0,
+      failureCount: 0,
+      errors: [],
+    });
+
+    firebaseAdminServiceMock = {
+      auth: {
+        importUsers: importUsersMock,
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ImportFirebaseAuthUsersCommand,
+        {
+          provide: getRepositoryToken(UserEntity, 'core'),
+          useValue: userRepositoryMock,
+        },
+        {
+          provide: FirebaseAdminService,
+          useValue: firebaseAdminServiceMock,
+        },
+      ],
+    }).compile();
+
+    command = module.get<ImportFirebaseAuthUsersCommand>(
+      ImportFirebaseAuthUsersCommand,
+    );
+
+    loggerLogSpy = jest.spyOn((command as any).logger, 'log').mockImplementation();
+    loggerErrorSpy = jest.spyOn((command as any).logger, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should log when no users are found', async () => {
+    userRepositoryMock.find.mockResolvedValueOnce([]);
+
+    await command.run([], {});
+
+    expect(loggerLogSpy).toHaveBeenCalledWith('No users found to import.');
+    expect(importUsersMock).not.toHaveBeenCalled();
+  });
+
+  it('should map users correctly and perform dry run', async () => {
+    const mockUsers = [
+      {
+        id: 'user1',
+        email: 'user1@example.com',
+        passwordHash: 'hash1',
+        isEmailVerified: true,
+        disabled: false,
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      {
+        id: 'user2',
+        email: 'user2@example.com',
+        passwordHash: 'hash2',
+        isEmailVerified: false,
+        disabled: true,
+        firstName: 'Jane',
+        lastName: 'Smith',
+      },
+    ];
+
+    userRepositoryMock.find.mockResolvedValueOnce(mockUsers);
+
+    await command.run([], { dryRun: true });
+
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      `[DRY RUN] Would import ${mockUsers.length} users into Firebase Auth.`,
+    );
+    expect(importUsersMock).not.toHaveBeenCalled();
+  });
+
+  it('should map users correctly and import them into Firebase Auth', async () => {
+    const mockUsers = [
+      {
+        id: 'user1',
+        email: 'user1@example.com',
+        passwordHash: 'hash1',
+        isEmailVerified: true,
+        disabled: false,
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ];
+
+    userRepositoryMock.find.mockResolvedValueOnce(mockUsers);
+    importUsersMock.mockResolvedValueOnce({
+      successCount: 1,
+      failureCount: 0,
+      errors: [],
+    });
+
+    await command.run([], {});
+
+    expect(importUsersMock).toHaveBeenCalledTimes(1);
+    expect(importUsersMock).toHaveBeenCalledWith(
+      [
+        {
+          uid: 'user1',
+          email: 'user1@example.com',
+          passwordHash: Buffer.from('hash1'),
+          emailVerified: true,
+          disabled: false,
+          displayName: 'John Doe',
+        },
+      ],
+      { hash: { algorithm: 'BCRYPT' } },
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith('Successfully imported: 1');
+  });
+
+  it('should batch users for import if more than 1000 users exist', async () => {
+    const mockUsers = Array.from({ length: 1500 }).map((_, i) => ({
+      id: `user${i}`,
+      email: `user${i}@example.com`,
+      passwordHash: `hash${i}`,
+      isEmailVerified: true,
+      disabled: false,
+      firstName: `User`,
+      lastName: `${i}`,
+    }));
+
+    userRepositoryMock.find.mockResolvedValueOnce(mockUsers);
+    importUsersMock
+      .mockResolvedValueOnce({ successCount: 1000, failureCount: 0, errors: [] })
+      .mockResolvedValueOnce({ successCount: 500, failureCount: 0, errors: [] });
+
+    await command.run([], {});
+
+    expect(importUsersMock).toHaveBeenCalledTimes(2);
+
+    // First call with first 1000
+    expect(importUsersMock).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([expect.objectContaining({ uid: 'user0' })]),
+      { hash: { algorithm: 'BCRYPT' } }
+    );
+    const call1Args = importUsersMock.mock.calls[0][0];
+    expect(call1Args.length).toBe(1000);
+
+    // Second call with remaining 500
+    expect(importUsersMock).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([expect.objectContaining({ uid: 'user1000' })]),
+      { hash: { algorithm: 'BCRYPT' } }
+    );
+    const call2Args = importUsersMock.mock.calls[1][0];
+    expect(call2Args.length).toBe(500);
+
+    expect(loggerLogSpy).toHaveBeenCalledWith('Successfully imported: 1500');
+  });
+
+  it('should log errors for individual failed user imports', async () => {
+    const mockUsers = [
+      {
+        id: 'user1',
+        email: 'user1@example.com',
+        passwordHash: 'hash1',
+        isEmailVerified: true,
+        disabled: false,
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ];
+
+    userRepositoryMock.find.mockResolvedValueOnce(mockUsers);
+
+    const mockError = { index: 0, error: new Error('Some error') };
+    importUsersMock.mockResolvedValueOnce({
+      successCount: 0,
+      failureCount: 1,
+      errors: [mockError],
+    });
+
+    await command.run([], {});
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Failed to import user at index 0 in chunk 0:',
+      mockError.error,
+    );
+    expect(loggerErrorSpy).toHaveBeenCalledWith('Failed to import: 1');
+  });
+});

--- a/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.ts
+++ b/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.ts
@@ -1,0 +1,101 @@
+import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as admin from 'firebase-admin';
+import { Command } from 'nest-commander';
+import { Not, IsNull, Repository } from 'typeorm';
+
+import { MigrationCommandRunner } from 'src/database/commands/command-runners/migration.command-runner';
+import { FirebaseAdminService } from 'src/engine/core-modules/firebase/firebase-admin.service';
+import { UserEntity } from 'src/engine/core-modules/user/user.entity';
+
+@Command({
+  name: 'database:import-firebase-auth-users',
+  description: 'Imports legacy users from PostgreSQL into Firebase Authentication.',
+})
+export class ImportFirebaseAuthUsersCommand extends MigrationCommandRunner {
+  constructor(
+    @InjectRepository(UserEntity, 'core')
+    protected readonly userRepository: Repository<UserEntity>,
+    protected readonly firebaseAdminService: FirebaseAdminService,
+  ) {
+    super();
+  }
+
+  public async runMigrationCommand(
+    _passedParams: string[],
+    options: { dryRun?: boolean; verbose?: boolean },
+  ): Promise<void> {
+    try {
+      this.logger.log(`Fetching users with passwords from PostgreSQL...`);
+      const users = await this.userRepository.find({
+        where: { passwordHash: Not(IsNull()) },
+        withDeleted: true,
+      });
+
+      if (users.length === 0) {
+        this.logger.log(`No users found to import.`);
+        return;
+      }
+
+      this.logger.log(`Found ${users.length} users with password hashes.`);
+
+      const records: admin.auth.UserImportRecord[] = users.map((user) => ({
+        uid: user.id,
+        email: user.email,
+        passwordHash: Buffer.from(user.passwordHash),
+        emailVerified: user.isEmailVerified,
+        disabled: user.disabled,
+        displayName: `${user.firstName} ${user.lastName}`.trim(),
+      }));
+
+      if (options.dryRun) {
+        this.logger.log(
+          `[DRY RUN] Would import ${records.length} users into Firebase Auth.`,
+        );
+        return;
+      }
+
+      this.logger.log(`Importing ${records.length} users into Firebase Auth...`);
+
+      const BATCH_LIMIT = 1000;
+      let successCount = 0;
+      let failureCount = 0;
+
+      for (let i = 0; i < records.length; i += BATCH_LIMIT) {
+        const chunk = records.slice(i, i + BATCH_LIMIT);
+
+        try {
+          const result = await this.firebaseAdminService.auth.importUsers(
+            chunk,
+            { hash: { algorithm: 'BCRYPT' } }
+          );
+
+          successCount += result.successCount;
+          failureCount += result.failureCount;
+
+          if (result.failureCount > 0) {
+            result.errors.forEach((err) => {
+              this.logger.error(
+                `Failed to import user at index ${err.index} in chunk ${i / BATCH_LIMIT}:`,
+                err.error,
+              );
+            });
+          }
+        } catch (error) {
+           this.logger.error(`Failed to import batch starting at index ${i}`, error);
+           throw error;
+        }
+      }
+
+      this.logger.log(`Import complete.`);
+      this.logger.log(`Successfully imported: ${successCount}`);
+      if (failureCount > 0) {
+         this.logger.error(`Failed to import: ${failureCount}`);
+      }
+
+    } catch (error) {
+      this.logger.error(`Failed to import firebase auth users.`, error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces the `database:import-firebase-auth-users` command, allowing developers and administrators to bulk migrate existing legacy users from PostgreSQL to Firebase Authentication. 

This bridges the gap caused by the backend architectural pivot, ensuring users can log in via Firebase using their existing BCRYPT-hashed passwords.

**Key Changes:**
* Added `ImportFirebaseAuthUsersCommand` (`packages/twenty-server/src/database/commands/import-firebase-auth-users.command.ts`).
* Added `import-firebase-auth-users.command.spec.ts` unit tests.
* Registered the command within `DatabaseCommandModule`.
* Utilizes a `BATCH_LIMIT` of 1000 records to safely invoke `firebaseAdminService.auth.importUsers`.
* Safely casts existing PostgreSQL `passwordHash` strings into Node `Buffer` instances as expected by the `importUsers` payload with algorithm config `BCRYPT`.

---
*PR created automatically by Jules for task [16050788762967209626](https://jules.google.com/task/16050788762967209626) started by @dllewellyn*