### PR TITLE
Fix Firebase Auth Import for OAuth Users

### DIFF
--- a/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.spec.ts
@@ -133,7 +133,10 @@ describe('ImportFirebaseAuthUsersCommand', () => {
       ],
       { hash: { algorithm: 'BCRYPT' } },
     );
-    expect(loggerLogSpy).toHaveBeenCalledWith('Successfully imported: 1');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Summary:');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Total Processed: 1');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Success Count: 1');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Failure Count: 0');
   });
 
   it('should batch users for import if more than 1000 users exist', async () => {
@@ -174,7 +177,10 @@ describe('ImportFirebaseAuthUsersCommand', () => {
     const call2Args = importUsersMock.mock.calls[1][0];
     expect(call2Args.length).toBe(500);
 
-    expect(loggerLogSpy).toHaveBeenCalledWith('Successfully imported: 1500');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Summary:');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Total Processed: 1500');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Success Count: 1500');
+    expect(loggerLogSpy).toHaveBeenCalledWith('Failure Count: 0');
   });
 
   it('should log errors for individual failed user imports', async () => {
@@ -205,6 +211,6 @@ describe('ImportFirebaseAuthUsersCommand', () => {
       'Failed to import user at index 0 in chunk 0:',
       mockError.error,
     );
-    expect(loggerErrorSpy).toHaveBeenCalledWith('Failed to import: 1');
+    expect(loggerErrorSpy).toHaveBeenCalledWith('Failure Count: 1');
   });
 });

--- a/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.ts
+++ b/packages/twenty-server/src/database/commands/import-firebase-auth-users.command.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as admin from 'firebase-admin';
 import { Command } from 'nest-commander';
-import { Not, IsNull, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { MigrationCommandRunner } from 'src/database/commands/command-runners/migration.command-runner';
 import { FirebaseAdminService } from 'src/engine/core-modules/firebase/firebase-admin.service';
@@ -26,9 +26,8 @@ export class ImportFirebaseAuthUsersCommand extends MigrationCommandRunner {
     options: { dryRun?: boolean; verbose?: boolean },
   ): Promise<void> {
     try {
-      this.logger.log(`Fetching users with passwords from PostgreSQL...`);
+      this.logger.log(`Fetching all users from PostgreSQL...`);
       const users = await this.userRepository.find({
-        where: { passwordHash: Not(IsNull()) },
         withDeleted: true,
       });
 
@@ -37,16 +36,23 @@ export class ImportFirebaseAuthUsersCommand extends MigrationCommandRunner {
         return;
       }
 
-      this.logger.log(`Found ${users.length} users with password hashes.`);
+      this.logger.log(`Found ${users.length} users.`);
 
-      const records: admin.auth.UserImportRecord[] = users.map((user) => ({
-        uid: user.id,
-        email: user.email,
-        passwordHash: Buffer.from(user.passwordHash),
-        emailVerified: user.isEmailVerified,
-        disabled: user.disabled,
-        displayName: `${user.firstName} ${user.lastName}`.trim(),
-      }));
+      const records: admin.auth.UserImportRecord[] = users.map((user) => {
+        const record: admin.auth.UserImportRecord = {
+          uid: user.id,
+          email: user.email,
+          emailVerified: user.isEmailVerified,
+          disabled: user.disabled,
+          displayName: `${user.firstName} ${user.lastName}`.trim(),
+        };
+
+        if (user.passwordHash) {
+          record.passwordHash = Buffer.from(user.passwordHash);
+        }
+
+        return record;
+      });
 
       if (options.dryRun) {
         this.logger.log(
@@ -88,9 +94,13 @@ export class ImportFirebaseAuthUsersCommand extends MigrationCommandRunner {
       }
 
       this.logger.log(`Import complete.`);
-      this.logger.log(`Successfully imported: ${successCount}`);
+      this.logger.log(`Summary:`);
+      this.logger.log(`Total Processed: ${records.length}`);
+      this.logger.log(`Success Count: ${successCount}`);
       if (failureCount > 0) {
-         this.logger.error(`Failed to import: ${failureCount}`);
+         this.logger.error(`Failure Count: ${failureCount}`);
+      } else {
+         this.logger.log(`Failure Count: ${failureCount}`);
       }
 
     } catch (error) {


### PR DESCRIPTION
Fixes an issue in the Firebase Auth migration script where only users with passwords were imported. Now all users, including OAuth users, are correctly imported to maintain UID consistency with their Firestore documents.

Additionally, refined logging metrics for better monitoring of success and failure counts.

---
*PR created automatically by Jules for task [16340469674888474377](https://jules.google.com/task/16340469674888474377) started by @dllewellyn*