### PR TITLE
feat(database): Add audit data migration command

### DIFF
--- a/packages/twenty-server/src/database/commands/audit-data-migration.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/audit-data-migration.command.spec.ts
@@ -272,4 +272,32 @@ describe('AuditDataMigrationCommand', () => {
       expect.stringContaining('mismatch on relation companyId'),
     );
   });
+
+  it('should log array field mismatches', async () => {
+    const workspaceId = 'test-workspace-id';
+
+    mockRepository.count.mockResolvedValue(1);
+    mockFirestoreCount.data.mockReturnValue({ count: 1 });
+
+    const date = new Date('2023-01-01T00:00:00.000Z');
+    const emails = { primaryEmail: 'test@example.com' };
+    mockRepository.find.mockResolvedValue([{ id: '1', createdAt: date, emails }]);
+
+    mockFirestoreDoc.exists = true;
+    // Missing the correct emails mapping
+    mockFirestoreDoc.data.mockReturnValue({ id: '1', createdAt: '2023-01-01T00:00:00.000Z', emails: [] });
+
+    mockSchemaValidator.validator.mockReturnValueOnce(true);
+
+    await command.runOnWorkspace({
+      workspaceId,
+      options: { workspaceIds: [] },
+      index: 0,
+      total: 1,
+    });
+
+    expect(command['logger'].log).toHaveBeenCalledWith(
+      expect.stringContaining('mismatch on array field emails'),
+    );
+  });
 });

--- a/packages/twenty-server/src/database/commands/audit-data-migration.command.ts
+++ b/packages/twenty-server/src/database/commands/audit-data-migration.command.ts
@@ -12,7 +12,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
 import { MetadataService } from 'src/engine/metadata-modules/metadata.service';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
-import { getArrayTransformedField } from 'src/database/utils/migration-transformation.util';
+import { transformEmailsToFirestore, transformLinksToFirestore, transformPhonesToFirestore } from 'src/database/utils/migration-transformation.util';
 
 @Command({
   name: 'database:audit-data-migration',
@@ -159,11 +159,20 @@ export class AuditDataMigrationCommand extends ActiveOrSuspendedWorkspacesMigrat
             const arrayFields = ['emails', 'phones', 'links'];
             for (const field of arrayFields) {
                if (pgRecord[field] !== undefined) {
-                  const expectedArray = getArrayTransformedField(pgRecord[field]);
-                  const stringifiedExpected = JSON.stringify(expectedArray);
+                  let expectedArray: any = null;
+
+                  if (field === 'emails') {
+                    expectedArray = transformEmailsToFirestore(pgRecord[field]);
+                  } else if (field === 'phones') {
+                    expectedArray = transformPhonesToFirestore(pgRecord[field]);
+                  } else if (field === 'links') {
+                    expectedArray = transformLinksToFirestore(pgRecord[field]);
+                  }
+
+                  const stringifiedExpected = JSON.stringify(expectedArray || []);
                   const stringifiedActual = JSON.stringify(fsData[field] || []);
 
-                  if (stringifiedExpected !== stringifiedActual && !(stringifiedExpected === '[]' && stringifiedActual === 'null')) {
+                  if (stringifiedExpected !== stringifiedActual) {
                      this.logger.log(
                         chalk.red(
                            `[${collection.name}] Record ${pgRecord.id} mismatch on array field ${field}. Expected: ${stringifiedExpected}, Actual: ${stringifiedActual}`,


### PR DESCRIPTION
Adds `database:audit-data-migration` command to audit data migrating from Postgres to Firestore. It compares overall document counts and basic data validation using workspace contexts and Firestore batch querying. Tests included.

---
*PR created automatically by Jules for task [7040467352777680950](https://jules.google.com/task/7040467352777680950) started by @dllewellyn*