### PR TITLE
feat: Frontend Permission Handling

### DIFF
--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -101,6 +101,14 @@ export const useApolloFactory = (options: Partial<Options<any>> = {}) => {
           },
         });
       },
+      onForbiddenError: (message) => {
+        enqueueErrorSnackBar({
+          message,
+          options: {
+            dedupeKey: 'forbidden-error',
+          },
+        });
+      },
       extraLinks: [],
       isDebugMode: process.env.IS_DEBUG_MODE === 'true',
       // Override options

--- a/packages/twenty-front/src/modules/apollo/services/__tests__/apollo.factory.test.ts
+++ b/packages/twenty-front/src/modules/apollo/services/__tests__/apollo.factory.test.ts
@@ -20,6 +20,7 @@ jest.mock('~/modules/auth/firebase', () => ({
 const mockOnError = jest.fn();
 const mockOnNetworkError = jest.fn();
 const mockOnPayloadTooLarge = jest.fn();
+const mockOnForbiddenError = jest.fn();
 
 const mockWorkspaceMember = {
   id: 'workspace-member-id',
@@ -79,6 +80,7 @@ const createMockOptions = (): Options<any> => ({
   onError: mockOnError,
   onNetworkError: mockOnNetworkError,
   onPayloadTooLarge: mockOnPayloadTooLarge,
+  onForbiddenError: mockOnForbiddenError,
   appVersion: '1.0.0',
 });
 
@@ -239,6 +241,49 @@ describe('ApolloFactory', () => {
       expect(mockOnPayloadTooLarge).toHaveBeenCalledWith(
         expect.stringContaining('Uploaded content is too large'),
       );
+    }
+  }, 10000);
+
+  it('should call onForbiddenError when encountering a 403 error', async () => {
+    fetchMock.mockResponse(() =>
+      Promise.reject({
+        statusCode: 403,
+        message: 'Forbidden',
+      }),
+    );
+
+    try {
+      await makeRequest();
+    } catch {
+      expect(mockOnForbiddenError).toHaveBeenCalledWith(
+        expect.stringContaining("You don't have permission to perform this action"),
+      );
+    }
+  }, 10000);
+
+  it('should call onForbiddenError with proper message when encountering FORBIDDEN graphql error', async () => {
+    const errors = [
+      {
+        message: 'Forbidden',
+        extensions: {
+          code: 'FORBIDDEN',
+          userFriendlyMessage: 'Custom forbidden message'
+        },
+      },
+    ];
+    fetchMock.mockResponse(() =>
+      Promise.resolve({
+        body: JSON.stringify({
+          data: {},
+          errors,
+        }),
+      }),
+    );
+
+    try {
+      await makeRequest();
+    } catch {
+      expect(mockOnForbiddenError).toHaveBeenCalledWith('Custom forbidden message');
     }
   }, 10000);
 });

--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -52,6 +52,7 @@ export interface Options<TCacheShape> extends ApolloClientOptions<TCacheShape> {
   onUnauthenticatedError?: () => void;
   onAppVersionMismatch?: (message: string) => void;
   onPayloadTooLarge?: (message: string) => void;
+  onForbiddenError?: (message: string) => void;
   currentWorkspaceMember: CurrentWorkspaceMember | null;
   currentWorkspace: CurrentWorkspace | null;
   extraLinks?: ApolloLink[];
@@ -74,6 +75,7 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
       onUnauthenticatedError,
       onAppVersionMismatch,
       onPayloadTooLarge,
+      onForbiddenError,
       currentWorkspaceMember,
       currentWorkspace,
       extraLinks,
@@ -277,8 +279,26 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
                 }
                 case 'NOT_FOUND':
                 case 'BAD_USER_INPUT':
-                case 'FORBIDDEN':
                 case 'CONFLICT':
+                  return;
+                case 'FORBIDDEN': {
+                  let message = t`You don't have permission to perform this action.`;
+                  const userFriendlyMessage =
+                    graphQLError.extensions?.userFriendlyMessage;
+                  if (typeof userFriendlyMessage === 'string') {
+                    message = userFriendlyMessage;
+                  } else if (
+                    userFriendlyMessage &&
+                    typeof userFriendlyMessage === 'object' &&
+                    'message' in userFriendlyMessage
+                  ) {
+                    message = String(
+                      (userFriendlyMessage as { message: unknown }).message,
+                    );
+                  }
+                  onForbiddenError?.(message);
+                  return;
+                }
                 case 'METADATA_VALIDATION_FAILED': {
                   return;
                 }
@@ -312,6 +332,13 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
 
             if (this.isPayloadTooLargeError(networkError as ServerError)) {
               onPayloadTooLarge?.(t`Uploaded content is too large.`);
+              return;
+            }
+
+            if ((networkError as ServerError).statusCode === 403) {
+              onForbiddenError?.(
+                t`You don't have permission to perform this action.`,
+              );
               return;
             }
 

--- a/packages/twenty-front/src/modules/error-handler/components/AppRootErrorFallback.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/AppRootErrorFallback.tsx
@@ -5,6 +5,8 @@ import { useContext } from 'react';
 import { IconReload } from 'twenty-ui/display';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
+import { isForbiddenError } from '@/error-handler/utils/isForbiddenError';
+
 type AppRootErrorFallbackProps = AppErrorDisplayProps;
 
 const StyledContainer = styled.div`
@@ -100,10 +102,18 @@ const StyledIconContainer = styled.span`
 `;
 
 export const AppRootErrorFallback = ({
+  error,
   resetErrorBoundary,
   title = t`Sorry, something went wrong`,
 }: AppRootErrorFallbackProps) => {
   const { theme } = useContext(ThemeContext);
+
+  const isForbidden = isForbiddenError(error);
+
+  const displayTitle = isForbidden ? t`Permission Denied` : title;
+  const displaySubtitle = isForbidden
+    ? t`You don't have the necessary roles or ownership permissions to view this content.`
+    : t`Please refresh the page.`;
 
   return (
     <StyledContainer>
@@ -120,10 +130,8 @@ export const AppRootErrorFallback = ({
             />
           </StyledImageContainer>
           <StyledEmptyTextContainer>
-            <StyledEmptyTitle>{title}</StyledEmptyTitle>
-            <StyledEmptySubTitle>
-              {t`Please refresh the page.`}
-            </StyledEmptySubTitle>
+            <StyledEmptyTitle>{displayTitle}</StyledEmptyTitle>
+            <StyledEmptySubTitle>{displaySubtitle}</StyledEmptySubTitle>
           </StyledEmptyTextContainer>
           <StyledButton onClick={resetErrorBoundary}>
             <StyledIconContainer>

--- a/packages/twenty-front/src/modules/error-handler/components/internal/AppErrorDisplay.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/internal/AppErrorDisplay.tsx
@@ -2,6 +2,8 @@ import { type AppErrorDisplayProps } from '@/error-handler/types/AppErrorDisplay
 import { t } from '@lingui/core/macro';
 import { IconRefresh } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
+import { isForbiddenError } from '@/error-handler/utils/isForbiddenError';
+
 import {
   AnimatedPlaceholder,
   AnimatedPlaceholderEmptyContainer,
@@ -11,16 +13,26 @@ import {
 } from 'twenty-ui/layout';
 
 export const AppErrorDisplay = ({
+  error,
   resetErrorBoundary,
   title = t`Sorry, something went wrong`,
 }: AppErrorDisplayProps) => {
+  const isForbidden = isForbiddenError(error);
+
+  const displayTitle = isForbidden ? t`Permission Denied` : title;
+  const displaySubtitle = isForbidden
+    ? t`You don't have the necessary roles or ownership permissions to view this content.`
+    : t`Please refresh the page.`;
+
   return (
     <AnimatedPlaceholderEmptyContainer>
       <AnimatedPlaceholder type="errorIndex" />
       <AnimatedPlaceholderEmptyTextContainer>
-        <AnimatedPlaceholderEmptyTitle>{title}</AnimatedPlaceholderEmptyTitle>
+        <AnimatedPlaceholderEmptyTitle>
+          {displayTitle}
+        </AnimatedPlaceholderEmptyTitle>
         <AnimatedPlaceholderEmptySubTitle>
-          {t`Please refresh the page.`}
+          {displaySubtitle}
         </AnimatedPlaceholderEmptySubTitle>
       </AnimatedPlaceholderEmptyTextContainer>
       <Button

--- a/packages/twenty-front/src/modules/error-handler/utils/__tests__/isForbiddenError.spec.ts
+++ b/packages/twenty-front/src/modules/error-handler/utils/__tests__/isForbiddenError.spec.ts
@@ -1,0 +1,75 @@
+import { ApolloError } from '@apollo/client';
+import { isForbiddenError } from '../isForbiddenError';
+
+describe('isForbiddenError', () => {
+  it('should return true for a GraphQL FORBIDDEN error', () => {
+    const error = new ApolloError({
+      graphQLErrors: [
+        {
+          message: 'Forbidden',
+          extensions: { code: 'FORBIDDEN' },
+          nodes: [],
+          source: undefined,
+          positions: [],
+          path: [],
+          originalError: undefined,
+        } as any,
+      ],
+    });
+    expect(isForbiddenError(error)).toBe(true);
+  });
+
+  it('should return true for a network 403 error', () => {
+    // Note: When ApolloError is constructed with a networkError that is an object
+    // without standard Error features, it might get mangled.
+    // We'll test our object directly rather than wrapping in ApolloError
+    // to match real-world usages where the object is passed directly.
+    const error = {
+      networkError: {
+        statusCode: 403,
+        name: 'ServerError',
+        message: 'Forbidden',
+      },
+    };
+    expect(isForbiddenError(error)).toBe(true);
+  });
+
+  it('should return true for regular 403 status objects', () => {
+    expect(isForbiddenError({ statusCode: 403 })).toBe(true);
+    expect(isForbiddenError({ status: 403 })).toBe(true);
+    expect(isForbiddenError({ response: { status: 403 } })).toBe(true);
+  });
+
+  it('should return false for other GraphQL errors', () => {
+    const error = new ApolloError({
+      graphQLErrors: [
+        {
+          message: 'Not Found',
+          extensions: { code: 'NOT_FOUND' },
+          nodes: [],
+          source: undefined,
+          positions: [],
+          path: [],
+          originalError: undefined,
+        } as any,
+      ],
+    });
+    expect(isForbiddenError(error)).toBe(false);
+  });
+
+  it('should return false for other network errors', () => {
+    const error = new ApolloError({
+      networkError: {
+        statusCode: 404,
+        name: 'ServerError',
+        message: 'Not Found',
+      } as any,
+    });
+    expect(isForbiddenError(error)).toBe(false);
+  });
+
+  it('should return false if no error is provided', () => {
+    expect(isForbiddenError(null)).toBe(false);
+    expect(isForbiddenError(undefined)).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/error-handler/utils/isForbiddenError.ts
+++ b/packages/twenty-front/src/modules/error-handler/utils/isForbiddenError.ts
@@ -1,0 +1,26 @@
+export const isForbiddenError = (error: any): boolean => {
+  if (!error) return false;
+
+  if (
+    error.graphQLErrors?.some(
+      (err: any) => err?.extensions?.code === 'FORBIDDEN',
+    )
+  ) {
+    return true;
+  }
+
+  if (error.networkError && 'statusCode' in error.networkError) {
+    return (error.networkError as any).statusCode === 403;
+  }
+
+  // Handle regular Response errors from REST APIs
+  if (
+    error.statusCode === 403 ||
+    error.status === 403 ||
+    error.response?.status === 403
+  ) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
Implements comprehensive frontend handling for 403 Forbidden/Permission Denied errors originating from Firestore rules. Updates ApolloFactory to catch these network and GraphQL errors and routes them to user-friendly snackbars and page fallbacks instead of generic "Something went wrong" messages.

---
*PR created automatically by Jules for task [15900236415116536164](https://jules.google.com/task/15900236415116536164) started by @dllewellyn*