### PR TITLE
Validate firebaseWorkspaceId against Firestore Workspace Membership

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/firebase.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/firebase.auth.strategy.spec.ts
@@ -19,11 +19,19 @@ describe('FirebaseAuthStrategy', () => {
   let mockWorkspaceRepository: any;
   let mockUserWorkspaceRepository: any;
   let mockWorkspaceCacheService: any;
+  let mockFirestore: any;
 
   beforeEach(async () => {
+    mockFirestore = {
+      collection: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get: jest.fn(),
+    };
     mockFirebaseAdminService = {
       verifyIdToken: jest.fn(),
       setCustomClaims: jest.fn(),
+      firestore: mockFirestore,
     };
     mockUserRepository = {
       findOne: jest.fn(),
@@ -109,6 +117,10 @@ describe('FirebaseAuthStrategy', () => {
           byId: { 'wm-id': { id: 'wm-id' } },
         },
       });
+      mockFirestore.get.mockResolvedValue({
+        empty: false,
+        docs: [{ data: () => ({ id: 'wm-id' }) }],
+      });
 
       const result = await strategy.validate(request);
 
@@ -118,6 +130,43 @@ describe('FirebaseAuthStrategy', () => {
       expect(result.user.id).toBe('user-id');
       expect(result.workspace.id).toBe('workspace-id');
       expect(result.workspaceMember.id).toBe('wm-id');
+    });
+
+    it('should throw FORBIDDEN_EXCEPTION if workspace membership is missing in Firestore', async () => {
+      const token = 'valid-firebase-token';
+      const request = {
+        headers: {
+          authorization: `Bearer ${token}`,
+          'x-twenty-workspace-id': 'workspace-id',
+        },
+      } as unknown as Request;
+
+      (mockFirebaseAdminService.verifyIdToken as jest.Mock).mockResolvedValue({
+        email: 'test@example.com',
+      });
+      mockUserRepository.findOne.mockResolvedValue({
+        id: 'user-id',
+        email: 'test@example.com',
+      });
+      mockWorkspaceRepository.findOneBy.mockResolvedValue({
+        id: 'workspace-id',
+        activationStatus: 'ACTIVE',
+      });
+      mockUserWorkspaceRepository.findOne.mockResolvedValue({
+        id: 'uw-id',
+        userId: 'user-id',
+        workspaceId: 'workspace-id',
+      });
+      mockFirestore.get.mockResolvedValue({
+        empty: true,
+      });
+
+      await expect(strategy.validate(request)).rejects.toThrow(
+        new AuthException(
+          'User is not a member of the workspace in Firestore',
+          AuthExceptionCode.FORBIDDEN_EXCEPTION,
+        ),
+      );
     });
 
     it('should throw FORBIDDEN_EXCEPTION if firebase verification fails', async () => {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/firebase.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/firebase.auth.strategy.ts
@@ -120,6 +120,21 @@ export class FirebaseAuthStrategy extends PassportStrategy(
       );
     }
 
+    // Validate workspace membership in Firestore to prevent claim-spoofing
+    const firestoreWorkspaceMemberSnapshot = await this.firebaseAdminService.firestore
+      .collection('workspaceMembers')
+      .where('userId', '==', user.id)
+      .where('workspaceId', '==', workspaceId)
+      .limit(1)
+      .get();
+
+    if (firestoreWorkspaceMemberSnapshot.empty) {
+      throw new AuthException(
+        'User is not a member of the workspace in Firestore',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      );
+    }
+
     const userWithTokenData = {
       ...user,
       firebaseUid: decodedToken.uid,


### PR DESCRIPTION
This PR implements Task 1.9 by adding a validation step in `FirebaseAuthStrategy` that checks the user's membership against the `workspaceMembers` collection in Firestore. This ensures that the `workspaceId` claim in the Firebase JWT is valid and prevents potential spoofing.

Key changes:
1.  **FirebaseAdminService**: Added a `firestore` getter for direct Firestore access.
2.  **FirebaseAuthStrategy**: Added a query to `workspaceMembers` in Firestore using the authenticated user's ID and the target `workspaceId`.
3.  **Tests**: Updated `firebase.auth.strategy.spec.ts` with new test cases for successful and failed Firestore validation.

Fixes #76

---
*PR created automatically by Jules for task [4801284521344887930](https://jules.google.com/task/4801284521344887930) started by @dllewellyn*